### PR TITLE
CAN-19: Remove Python3.8 support; fix unit test

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.9", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/README.ipynb
+++ b/README.ipynb
@@ -6,9 +6,9 @@
    "source": [
     "# The Python `SomaData` Package from Somalogic, Inc.\n",
     "\n",
-    "![cover](https://img.shields.io/badge/coverage-97-success.svg?style=flat&logo=codecov)\n",
     "[![License:\n",
     "MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://choosealicense.com/licenses/mit/)\n",
+    "![PyPI Downloads](https://img.shields.io/pypi/dm/somadata?label=PyPI%20downloads)\n",
     "\n",
     "-----\n",
     "\n",
@@ -2216,11 +2216,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# using ittertools to sumulate some metadata:\n",
+    "# using ittertools to simulate some metadata:\n",
     "from itertools import cycle, islice\n",
     "import pandas as pd\n",
     "\n",
@@ -7471,11 +7471,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# because some common documentation refers to plex size intead of assay version the tool also supports lifing by naming plex size.\n",
+    "# because some common documentation refers to plex size instead of assay version the tool also supports lifing by naming plex size.\n",
     "lifted_adat = adat.lift('11K')"
    ]
   },
@@ -7725,7 +7725,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -7752,7 +7752,7 @@
    ],
    "source": [
     "# your exact transformation's Lin's CCC can be selected by filtering the column that contains your matrix and versions\n",
-    "# Lin's CCC are symetrical v5.0 -> v4.0 == v4.0 -> v5.0.\n",
+    "# Lin's CCC are symmetrical v5.0 -> v4.0 == v4.0 -> v5.0.\n",
     "ccc[\"Plasma Lin's CCC v5.0 11K to v4.0 5K\"]"
    ]
   },

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # The Python `SomaData` Package from Somalogic, Inc.
 
-![cover](https://img.shields.io/badge/coverage-97-success.svg?style=flat&logo=codecov)
 [![License:
 MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://choosealicense.com/licenses/mit/)
+![PyPI Downloads](https://img.shields.io/pypi/dm/somadata?label=PyPI%20downloads)
 
 -----
 
@@ -1994,7 +1994,7 @@ Row metadata is sample level information which could include added clinical data
 
 
 ```python
-# using ittertools to sumulate some metadata:
+# using ittertools to simulate some metadata:
 from itertools import cycle, islice
 import pandas as pd
 
@@ -5922,7 +5922,7 @@ lifted_adat
 
 
 ```python
-# because some common documentation refers to plex size intead of assay version the tool also supports lifing by naming plex size.
+# because some common documentation refers to plex size instead of assay version the tool also supports lifing by naming plex size.
 lifted_adat = adat.lift('11K')
 ```
 
@@ -6080,7 +6080,7 @@ The tool allows you to display Lin's concordance correlation coefficient ([Lin 1
 
 ```python
 # your exact transformation's Lin's CCC can be selected by filtering the column that contains your matrix and versions
-# Lin's CCC are symetrical v5.0 -> v4.0 == v4.0 -> v5.0.
+# Lin's CCC are symmetrical v5.0 -> v4.0 == v4.0 -> v5.0.
 ccc["Plasma Lin's CCC v5.0 11K to v4.0 5K"]
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "somadata"
-version = "1.0.0"
+version = "1.1.0"
 description = "SomaLogic Python Data Input/Output Library"
 authors = [
     "Joseph Allison",
@@ -8,7 +8,7 @@ authors = [
     "Kah Young"
     ]
 maintainers = [
-    "Standard Biotools <support@somalogic.com>"
+    "Standard BioTools <support@somalogic.com>"
 ]
 license = "MIT"
 readme = "README.md"
@@ -26,21 +26,15 @@ homepage = "https://www.standardbio.com/"
 repository = "https://github.com/SomaLogic/Canopy"
 
 [tool.poetry.dependencies]
-python = "^3.8"
-pandas = [
-    {version = "<=2.0.3", python = ">=3.8, <3.9"},
-    {version = ">=1.1.2", python = ">=3.9, <3.12"},
-    {version = "^2.2", python = ">=3.12"}
-]
-numpy = [
-    {version = ">=1.19,<1.25", python = ">=3.8,<3.9"},
-    {version = "^1.21", python = ">=3.9"}
-]
+python = "^3.9"
+pandas = ">=1.1.2"
+numpy = ">=1.19"
 openpyxl = "^3.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.1"
 codespell = "^2.2.6"
+pytest-cov = "^6.0.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_adat_math_helpers.py
+++ b/tests/test_adat_math_helpers.py
@@ -9,17 +9,18 @@ from somadata import Adat
 from somadata.data.lift import LiftData
 
 
-class TestAdatLift:
+class TestAdatLift(TestCase):
     filename = './tests/data/control_data.adat'
 
-    def __init__(self):
-        self.ld = LiftData('v4.0', 'v5.0', 'plasma')
-        self.adat = somadata.read_adat(self.filename)
-        self.lift_adat = self.adat.lift('v5.0')
+    @classmethod
+    def setUpClass(cls):
+        cls.ld = LiftData('v4.0', 'v5.0', 'plasma')
+        cls.adat = somadata.read_adat(cls.filename)
+        cls.lift_adat = cls.adat.lift('v5.0')
 
     def test_scaling_math(self):
         back_scalers = self.lift_adat.divide(self.adat).mean(axis=0)
-        # theres rounding error but we're lifting columns. The Ratio of lifted values is the scale factors again.
+        # there's rounding error but we're lifting columns. The Ratio of lifted values is the scale factors again.
         assert all(
             isclose(back_scalers.values, self.ld.scale_factors.values, atol=0.05)
         )
@@ -31,3 +32,15 @@ class TestAdatLift:
 
     def test_signal_space(self):
         assert self.lift_adat.header_metadata['SignalSpace'] == 'v5.0'
+
+    def test_e_lod_by_reagent(self):
+        e_lod_df = self.adat.e_lod_by_reagent()
+        assert not e_lod_df.empty
+        assert all(e_lod_df > 0)
+
+    def test_cv_decomp(self):
+        cv_decomp_df = self.adat.cv_decomp()
+        assert not cv_decomp_df.empty
+        assert 'Total' in cv_decomp_df.columns
+        assert 'Intra' in cv_decomp_df.columns
+        assert 'Inter' in cv_decomp_df.columns


### PR DESCRIPTION
- Deprecate Python 3.8
- Test support for Python 3.13
- Fix unit test
- README spelling and minor changes