### PR TITLE
CAN-20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "somadata"
-version = "1.1.0"
+version = "1.2.0"
 description = "SomaLogic Python Data Input/Output Library"
 authors = [
     "Joseph Allison",

--- a/somadata/__init__.py
+++ b/somadata/__init__.py
@@ -1,5 +1,8 @@
 from somadata.adat import Adat
 from somadata.annotations import Annotations
-from somadata.io.adat.file import read_file, read_adat
+from somadata.io.adat.file import read_file, read_adat, parse_file
 from somadata.io.annotations.file import read_annotations
-from somadata.tools.adat_concatenation import concatenate_adats, smart_adat_concatenation
+from somadata.tools.adat_concatenation import (
+    concatenate_adats,
+    smart_adat_concatenation,
+)

--- a/somadata/adat.py
+++ b/somadata/adat.py
@@ -101,8 +101,8 @@ class Adat(AdatMetaHelpers, AdatMathHelpers, pd.DataFrame, AdatNormalization):
     def to_adat(
         self,
         path_or_buf: Union[str, TextIO],
-        round_rfu: bool = True,
-        convert_to_v3_seq_ids: bool = False,
+        *args,
+        **kwargs,
     ) -> None:
         """Writes the adat to an adat formatted file with the given filename.
 
@@ -130,6 +130,6 @@ class Adat(AdatMetaHelpers, AdatMathHelpers, pd.DataFrame, AdatNormalization):
 
         if type(path_or_buf) == str:
             with open(path_or_buf, 'w', newline='', encoding='utf-8') as f:
-                io.adat.file.write_adat(self, f, round_rfu, convert_to_v3_seq_ids)
+                io.adat.file.write_adat(self, f, *args, **kwargs)
         else:
-            io.adat.file.write_adat(self, path_or_buf, round_rfu, convert_to_v3_seq_ids)
+            io.adat.file.write_adat(self, path_or_buf, *args, **kwargs)

--- a/tests/test_adat_reading.py
+++ b/tests/test_adat_reading.py
@@ -1,13 +1,14 @@
-from unittest import TestCase
-from somadata import Adat
-import somadata
-import pytest
 import os
+from unittest import TestCase
+
+import pytest
+
+import somadata
+from somadata import Adat
 
 
 class AdatReadingTest(TestCase):
-    """Tests if adat can be read in.
-    """
+    """Tests if adat can be read in."""
 
     filename = './tests/data/control_data.adat'
 
@@ -17,13 +18,15 @@ class AdatReadingTest(TestCase):
 
 
 class AdatAttrTest(TestCase):
-    """Tests that the data integrity is maintained after loading into the dataframe format.
-    """
+    """Tests that the data integrity is maintained after loading into the dataframe format."""
 
     filename = './tests/data/control_data.adat'
 
     def setUp(self):
         self.adat = somadata.read_adat(self.filename)
+        self.adat_compatibility = somadata.read_adat(
+            self.filename, compatibility_mode=True
+        )
 
     def test_adat_size(self):
         self.assertEqual(self.adat.shape, (11, 5284))
@@ -35,24 +38,72 @@ class AdatAttrTest(TestCase):
         self.assertEqual(len(self.adat.columns.names), 22)
 
     def test_row_metadata_names(self):
-        self.assertEqual(self.adat.index.names, [
-            'PlateId', 'PlateRunDate', 'ScannerID', 'PlatePosition', 'SlideId', 'Subarray',
-            'SampleId', 'SampleType', 'PercentDilution', 'SampleMatrix', 'Barcode',
-            'Barcode2d', 'SampleName', 'SampleNotes', 'AliquotingNotes', 'SampleDescription',
-            'AssayNotes', 'TimePoint', 'ExtIdentifier', 'SsfExtId', 'SampleGroup', 'SiteId',
-            'TubeUniqueID', 'CLI', 'HybControlNormScale', 'RowCheck', 'NormScale_20',
-            'NormScale_0_005', 'NormScale_0_5', 'ANMLFractionUsed_20',
-            'ANMLFractionUsed_0_005', 'ANMLFractionUsed_0_5'
-        ])
+        self.assertEqual(
+            self.adat.index.names,
+            [
+                'PlateId',
+                'PlateRunDate',
+                'ScannerID',
+                'PlatePosition',
+                'SlideId',
+                'Subarray',
+                'SampleId',
+                'SampleType',
+                'PercentDilution',
+                'SampleMatrix',
+                'Barcode',
+                'Barcode2d',
+                'SampleName',
+                'SampleNotes',
+                'AliquotingNotes',
+                'SampleDescription',
+                'AssayNotes',
+                'TimePoint',
+                'ExtIdentifier',
+                'SsfExtId',
+                'SampleGroup',
+                'SiteId',
+                'TubeUniqueID',
+                'CLI',
+                'HybControlNormScale',
+                'RowCheck',
+                'NormScale_20',
+                'NormScale_0_005',
+                'NormScale_0_5',
+                'ANMLFractionUsed_20',
+                'ANMLFractionUsed_0_005',
+                'ANMLFractionUsed_0_5',
+            ],
+        )
 
     def test_column_metadata_names(self):
-        self.assertEqual(self.adat.columns.names, [
-            'SeqId', 'SeqIdVersion', 'SomaId', 'TargetFullName', 'Target', 'UniProt',
-            'EntrezGeneID', 'EntrezGeneSymbol', 'Organism', 'Units', 'Type', 'Dilution',
-            'PlateScale_Reference', 'CalReference', 'Cal_P0024405', 'ColCheck',
-            'CalQcRatio_P0024405_170255', 'QcReference_170255', 'CalQcRatio_P0024405_170259',
-            'QcReference_170259', 'CalQcRatio_P0024405_170260', 'QcReference_170260'
-        ])
+        self.assertEqual(
+            self.adat.columns.names,
+            [
+                'SeqId',
+                'SeqIdVersion',
+                'SomaId',
+                'TargetFullName',
+                'Target',
+                'UniProt',
+                'EntrezGeneID',
+                'EntrezGeneSymbol',
+                'Organism',
+                'Units',
+                'Type',
+                'Dilution',
+                'PlateScale_Reference',
+                'CalReference',
+                'Cal_P0024405',
+                'ColCheck',
+                'CalQcRatio_P0024405_170255',
+                'QcReference_170255',
+                'CalQcRatio_P0024405_170259',
+                'QcReference_170259',
+                'CalQcRatio_P0024405_170260',
+                'QcReference_170260',
+            ],
+        )
 
     def test_header_metadata_size(self):
         self.assertEqual(len(self.adat.header_metadata.keys()), 38)
@@ -60,37 +111,71 @@ class AdatAttrTest(TestCase):
     def test_header_metadata_spot_check(self):
         self.assertEqual(self.adat.header_metadata['HybNormReference'], 'intraplate')
         self.assertEqual(self.adat.header_metadata['StudyOrganism'], '')
-        self.assertEqual(self.adat.header_metadata['PlateScale_Scalar_P0024405'], '0.78797188')
+        self.assertEqual(
+            self.adat.header_metadata['PlateScale_Scalar_P0024405'], '0.78797188'
+        )
+        self.assertIsInstance(self.adat.header_metadata["ReportConfig"], dict)
+        self.assertIsInstance(
+            self.adat_compatibility.header_metadata["ReportConfig"], str
+        )
 
     def test_row_metadata_spot_check(self):
-        self.assertEqual(list(self.adat.index.get_level_values('SampleId')), [
-            '170261', '190063', '170255', '170261', '190063', '170255', '170261',
-            '190063', '170261', '170255', '170261'
-        ])
+        self.assertEqual(
+            list(self.adat.index.get_level_values('SampleId')),
+            [
+                '170261',
+                '190063',
+                '170255',
+                '170261',
+                '190063',
+                '170255',
+                '170261',
+                '190063',
+                '170261',
+                '170255',
+                '170261',
+            ],
+        )
 
 
 class WrittenAdatAttrTest(AdatAttrTest):
-    """Reruns the same tests from AdatAttrTest but with a written file.
-    """
+    """Reruns the same tests from AdatAttrTest but with a written file."""
 
     filename = './tests/data/control_data_written.adat'
+    filename_compatibility_mode = './tests/data/control_data_written_compatible.adat'
 
     def setUp(self):
         first_adat = somadata.read_adat('./tests/data/control_data.adat')
         first_adat.to_adat(self.filename)
         self.adat = somadata.read_adat(self.filename)
+        second_adat = somadata.read_adat(
+            './tests/data/control_data.adat', compatibility_mode=True
+        )
+        second_adat.to_adat(self.filename_compatibility_mode)
+        self.adat_compatibility = somadata.read_adat(
+            self.filename_compatibility_mode, compatibility_mode=True
+        )
 
     def tearDown(self):
         if os.path.exists(self.filename):
             os.remove(self.filename)
+        if os.path.exists(self.filename_compatibility_mode):
+            os.remove(self.filename_compatibility_mode)
 
 
 class ConvertV3SeqIdsReadTestCase(TestCase):
     def setUp(self):
         rfu_data = [[1, 2, 3], [4, 5, 6]]
-        col_metadata = {'SeqId': ['12345-6_7', '23456-7_8', '34567-8_9'], 'ColCheck': ['PASS', 'FLAG', 'FLAG']}
+        col_metadata = {
+            'SeqId': ['12345-6_7', '23456-7_8', '34567-8_9'],
+            'ColCheck': ['PASS', 'FLAG', 'FLAG'],
+        }
         row_metadata = {'PlateId': ['A12', 'A12'], 'Barcode': ['SL1234', 'SL1235']}
-        header_metadata = {'AdatId': '1a2b3c', '!AssayRobot': 'Tecan1, Tecan2', 'RunNotes': 'run note 1'}
+        header_metadata = {
+            'AdatId': '1a2b3c',
+            '!AssayRobot': 'Tecan1, Tecan2',
+            'RunNotes': 'run note 1',
+        }
         adat = Adat.from_features(rfu_data, row_metadata, col_metadata, header_metadata)
         adat.to_adat('tests/data/v3_test.adat')
 
@@ -108,7 +193,7 @@ class ConvertV3SeqIdsReadTestCase(TestCase):
         # check that the message matches
         self.assertEqual(
             record[0].message.args[0],
-            'V3 style seqIds (i.e., 12345-6_7). Converting to V4 Style. The adat file writer has an option to write using the V3 style'
+            'V3 style seqIds (i.e., 12345-6_7). Converting to V4 Style. The adat file writer has an option to write using the V3 style',
         )
 
     @pytest.mark.filterwarnings('ignore:V3 style seqIds')
@@ -116,6 +201,13 @@ class ConvertV3SeqIdsReadTestCase(TestCase):
         adat = somadata.read_adat('tests/data/v3_test.adat')
 
         # check that the adat has the correct column metadata names and data
-        self.assertEqual(['SeqId', 'SeqIdVersion', 'ColCheck'], list(adat.columns.names))
-        self.assertEqual(['12345-6', '23456-7', '34567-8'], list(adat.columns.get_level_values('SeqId')))
-        self.assertEqual(['7', '8', '9'], list(adat.columns.get_level_values('SeqIdVersion')))
+        self.assertEqual(
+            ['SeqId', 'SeqIdVersion', 'ColCheck'], list(adat.columns.names)
+        )
+        self.assertEqual(
+            ['12345-6', '23456-7', '34567-8'],
+            list(adat.columns.get_level_values('SeqId')),
+        )
+        self.assertEqual(
+            ['7', '8', '9'], list(adat.columns.get_level_values('SeqIdVersion'))
+        )

--- a/tests/test_adat_writing.py
+++ b/tests/test_adat_writing.py
@@ -15,6 +15,7 @@ class AdatWritingTest(TestCase):
     """Tests if writing can occur and if the written file matches expectation (via md5)."""
 
     filename = './tests/data/control_data_written.adat'
+    filename_compatibility_mode = './tests/data/control_data_written_compatible.adat'
     source_filename = './tests/data/control_data.adat'
 
     def setUp(self):
@@ -22,10 +23,15 @@ class AdatWritingTest(TestCase):
         with open(self.source_filename, 'rb') as f:
             self.source_md5.update(f.read())
         self.adat = somadata.read_adat('./tests/data/control_data.adat')
+        self.adat_compatibility_mode = somadata.read_adat(
+            './tests/data/control_data.adat', compatibility_mode=True
+        )
 
     def tearDown(self):
         if os.path.exists(self.filename):
             os.remove(self.filename)
+        if os.path.exists(self.filename_compatibility_mode):
+            os.remove(self.filename_compatibility_mode)
 
     def test_adat_write(self):
         self.adat.to_adat(self.filename)
@@ -36,6 +42,14 @@ class AdatWritingTest(TestCase):
         self.adat.to_adat(self.filename)
         hash_md5 = hashlib.md5()
         with open(self.filename, 'rb') as f:
+            hash_md5.update(f.read())
+        self.assertEqual(hash_md5.hexdigest(), 'ff0f3b40b210999093d55e129276201e')
+
+    @mock.patch('somadata.io.adat.file.version', require_side_effect)
+    def test_adat_md5_compatibility(self):
+        self.adat_compatibility_mode.to_adat(self.filename_compatibility_mode)
+        hash_md5 = hashlib.md5()
+        with open(self.filename_compatibility_mode, 'rb') as f:
             hash_md5.update(f.read())
         self.assertEqual(hash_md5.hexdigest(), 'ff0f3b40b210999093d55e129276201e')
 


### PR DESCRIPTION
- Make parse_file easier to access
- Option to make ReportConfig in header str type
- Allow parse_file to accept a filename
- Remove deprecated write_file function