### PR TITLE
CAN-24: Fix ValueError when reading adats with Empty RFUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ pip install -e ./somadata
 
 ### Dependencies
 
-`Python >=3.8` is required to install `somadata`. The following package dependencies are installed on a `pip install`:
-  - `pandas >= 1.1.0`
+`Python >=3.9` is required to install `somadata`. The following package dependencies are installed on a `pip install`:
+  - `pandas >= 1.1.2`
   - `numpy >= 1.19.1`
 
 [return to top](#toptoc)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "somadata"
-version = "1.2.1"
+version = "1.2.2"
 description = "SomaLogic Python Data Input/Output Library"
 authors = [
     "Joseph Allison",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,33 @@
+import csv
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import somadata as sd
+
+
+@pytest.fixture(scope="session")
+def control_data_path() -> str:
+    return str(Path(__file__).parent / 'data' / 'control_data.adat')
+
+
+@pytest.fixture(scope="session")
+def control_data(control_data_path: str) -> sd.Adat:
+    return sd.read_adat(control_data_path)
+
+
+@pytest.fixture(scope="session")
+def missing_rfu_adat_path(control_data_path: str, tmp_path_factory) -> str:
+    fn = str(tmp_path_factory.mktemp("data") / "missing_rfu_test.adat")
+    # Read ADAT as TSV
+    with open(control_data_path, "r", newline="", encoding="utf-8") as f:
+        reader = [row for row in csv.reader(f, delimiter="\t")]
+    # Modify only the last row
+    if reader:
+        reader[-1] = reader[-1][:33]  # Keep only the first 33 columns (up to column AG)
+    # Write back to the file while preserving tab delimiters
+    with open(fn, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f, delimiter="\t")
+        writer.writerows(reader)
+    return fn

--- a/tests/io/adat/test_file.py
+++ b/tests/io/adat/test_file.py
@@ -1,0 +1,50 @@
+import io
+import logging
+
+import pytest
+
+from somadata.io.adat.file import parse_file
+
+
+def test_parse_file_with_missing_row_metadata(missing_rfu_adat_path: str, caplog):
+    with caplog.at_level(logging.WARNING):
+        rfu_matrix, row_metadata, column_metadata, header_metadata = parse_file(
+            missing_rfu_adat_path
+        )
+
+    # Assert that the warning was logged about missing row metadata
+    warning_message = (
+        "Row metadata has 3 missing values. Filling missing entries with empty strings."
+    )
+    assert any(
+        warning_message in record.message for record in caplog.records
+    ), "Expected warning about missing row metadata not found."
+
+    # Verify row_metadata structure is correctly filled
+    # First row is fine
+    assert row_metadata["ANMLFractionUsed_20"] == [
+        '',
+        '',
+        '0.817',
+        '',
+        '',
+        '0.791',
+        '',
+        '',
+        '',
+        '0.832',
+        '',
+    ]
+    assert row_metadata["ANMLFractionUsed_0_5"] == [
+        '',
+        '',
+        '0.836',
+        '',
+        '',
+        '0.829',
+        '',
+        '',
+        '',
+        '0.840',
+        '',
+    ]


### PR DESCRIPTION
ValueError on reading index for some adats occur when RFU values for the entire sample is missing and the last columns of row metadata are empty.

Proposed fix: Fill in the row metadata with empty strings so the adat object can be created.