### PR TITLE
CAN-50: Phase 4 — v2.0 reader dispatch and field type validation

### DIFF
--- a/somadata/conversion/_helpers.py
+++ b/somadata/conversion/_helpers.py
@@ -354,17 +354,17 @@ def match_qc_reference(name: str) -> str | None:
 
 def try_float(value: str) -> float | None:
     """Return *value* as float, or ``None`` on failure.
-    
+
     Parameters
     ----------
     value : str
         String value to convert to float.
-    
+
     Returns
     -------
     float or None
         Float value if conversion succeeds, None otherwise.
-    
+
     Examples
     --------
     >>> try_float('1.23')
@@ -382,17 +382,17 @@ def derive_hyb_norm_status(scale_factor: str) -> str:
     """Return ``'PASS'`` if 0.4 <= float(scale_factor) <= 2.5, else ``'FLAG'``.
 
     Returns ``''`` for missing / non-numeric values.
-    
+
     Parameters
     ----------
     scale_factor : str
         HybNormScaleFactor value to check.
-    
+
     Returns
     -------
     str
         'PASS', 'FLAG', or '' (empty for non-numeric).
-    
+
     Examples
     --------
     >>> derive_hyb_norm_status('1.0')
@@ -410,19 +410,19 @@ def derive_hyb_norm_status(scale_factor: str) -> str:
 
 def derive_hyb_norm_status_vectorized(scale_factors: list[str]) -> list[str]:
     """Vectorized version of HybNormStatus derivation.
-    
+
     Returns 'PASS' if 0.4 <= float(value) <= 2.5, else 'FLAG', or '' for non-numeric.
-    
+
     Parameters
     ----------
     scale_factors : list[str]
         HybNormScaleFactor values for all rows.
-    
+
     Returns
     -------
     list[str]
         Status values ('PASS', 'FLAG', or '') for each row.
-    
+
     Examples
     --------
     >>> derive_hyb_norm_status_vectorized(['1.0', '3.0', 'invalid'])
@@ -430,17 +430,17 @@ def derive_hyb_norm_status_vectorized(scale_factors: list[str]) -> list[str]:
     """
     arr = np.array(scale_factors, dtype=object)
     result = np.full(len(arr), '', dtype=object)
-    
+
     try:
         numeric = pd.to_numeric(arr, errors='coerce')
         valid_mask = ~np.isnan(numeric)
-        
+
         pass_mask = valid_mask & (numeric >= 0.4) & (numeric <= 2.5)
         flag_mask = valid_mask & ~pass_mask
-        
+
         result[pass_mask] = 'PASS'
         result[flag_mask] = 'FLAG'
     except Exception:
         return [derive_hyb_norm_status(v) for v in scale_factors]
-    
+
     return result.tolist()

--- a/somadata/conversion/array/row_data.py
+++ b/somadata/conversion/array/row_data.py
@@ -150,10 +150,10 @@ def _derive_med_norm_int_status_vectorized(
     out_levels: dict[str, list],
 ) -> list[str]:
     """Vectorized MedNormIntStatus derivation for all rows.
-    
+
     Only applies to Calibrator and Buffer sample types. All NormScale_* values
     for a row must be numeric and in range [0.4, 2.5] for PASS.
-    
+
     Parameters
     ----------
     sample_types : list[str]
@@ -162,7 +162,7 @@ def _derive_med_norm_int_status_vectorized(
         Names of all NormScale_* fields present.
     out_levels : dict[str, list]
         The output levels dict containing NormScale_* arrays.
-    
+
     Returns
     -------
     list[str]
@@ -170,39 +170,39 @@ def _derive_med_norm_int_status_vectorized(
     """
     n_rows = len(sample_types)
     result = [''] * n_rows
-    
+
     if not norm_scale_level_names:
         return result
-    
+
     # Build matrix of all NormScale values (rows × norm_scale_fields)
     norm_matrix = []
     for field_name in norm_scale_level_names:
         norm_matrix.append(out_levels[field_name])
-    
+
     # Process only eligible sample types
     for i in range(n_rows):
         stype = sample_types[i]
         if stype not in _MED_NORM_INT_ELIGIBLE:
             continue
-        
+
         # Collect all NormScale values for this row
         values = [norm_matrix[j][i] for j in range(len(norm_scale_level_names))]
         if not values:
             continue
-        
+
         # Try converting all to float
         try:
             floats = [float(v) if v else None for v in values]
         except (ValueError, TypeError):
             continue
-        
+
         # Check if all are valid and in range
         if all(f is not None for f in floats):
             if all(0.4 <= f <= 2.5 for f in floats):  # type: ignore[operator]
                 result[i] = 'PASS'
             else:
                 result[i] = 'FLAG'
-    
+
     return result
 
 
@@ -267,14 +267,14 @@ def convert_array_row_data(
     #    - Otherwise, leave blank
     # ------------------------------------------------------------------
     sample_type_vals = out_levels.get('SampleType', [''] * n_rows)
-    
+
     # Ensure Project field exists
     if 'Project' not in out_levels:
         out_levels['Project'] = [''] * n_rows
-    
+
     # Get Title from header once (used for fallback)
     title_from_header = lookup_header(getattr(adat, 'header_metadata', {}), 'Title')
-    
+
     # Apply fallback logic for study samples
     for i in range(n_rows):
         stype = sample_type_vals[i] if i < len(sample_type_vals) else ''
@@ -291,7 +291,7 @@ def convert_array_row_data(
             # Try Title fallback from header
             if title_from_header:
                 out_levels['Project'][i] = title_from_header
-    
+
     # ------------------------------------------------------------------
     # 3. Identify NormScale_* levels (needed for MedNormIntStatus)
     # ------------------------------------------------------------------
@@ -338,7 +338,7 @@ def convert_array_row_data(
     # 8. New generated fields (one value per row)
     # ------------------------------------------------------------------
     out_levels['SampleReadout'] = ['Array'] * n_rows
-    
+
     # Only generate for missing/blank keys
     if 'UniqueSampleKey' in out_levels:
         # Some keys may already exist; only generate for missing/blank
@@ -350,7 +350,7 @@ def convert_array_row_data(
     else:
         # No existing keys; generate all
         out_levels['UniqueSampleKey'] = [generate_guid() for _ in range(n_rows)]
-    
+
     out_levels['SourceFileId'] = [ctx.source_file_id] * n_rows
     out_levels['ProcessStepsId'] = [ctx.process_steps_id] * n_rows
     out_levels['ReportConfigId'] = [ctx.report_config_id] * n_rows

--- a/somadata/conversion/converter.py
+++ b/somadata/conversion/converter.py
@@ -13,12 +13,16 @@ from somadata.conversion.array.header import convert_array_header
 from somadata.conversion.array.row_data import convert_array_row_data
 from somadata.conversion.array.validation import validate_source_array_adat
 from somadata.conversion.detection import InputType, detect_input_type
-from somadata.conversion.errors import AssayVersionError, ConversionError, UnsupportedCombinationError
+from somadata.conversion.errors import (
+    AssayVersionError,
+    ConversionError,
+    UnsupportedCombinationError,
+)
 from somadata.conversion.merge import (
+    _merge_col_data,
     compute_seqid_union,
     merge_mixed_headers,
     validate_mednorm_compatibility,
-    _merge_col_data,
 )
 from somadata.conversion.ngs import NGSConversionContext
 from somadata.conversion.ngs.col_data import convert_ngs_col_data
@@ -207,7 +211,9 @@ def _merge_bridged_array_and_ngs(
     # 4. Run per-source conversions with assay_type='Mixed'
     validate_source_array_adat(raw_array)
     array_header_v2 = convert_array_header(raw_array, array_ctx, assay_type='Mixed')
-    array_columns_v2 = convert_array_col_data(raw_array, calibrator_id=array_ctx.calibrator_id)
+    array_columns_v2 = convert_array_col_data(
+        raw_array, calibrator_id=array_ctx.calibrator_id
+    )
     array_index_v2 = convert_array_row_data(raw_array, array_ctx)
 
     validate_source_ngs_adat(raw_ngs)
@@ -269,7 +275,7 @@ def _merge_bridged_array_and_v2(
     med_norm_ref: str | None,
 ) -> Adat:
     """Merge a bridged array ADAT and an existing v2.0 ADAT into a Mixed v2.0 output.
-    
+
     The v2.0 input can be Array, NGS, or Mixed. MedNorm validation is applied
     based on the v2.0's AssayType.
     """
@@ -281,7 +287,7 @@ def _merge_bridged_array_and_v2(
     else:
         raw_array, v2_adat = adat_b, adat_a
         md5_array, md5_v2 = md5sum_b, md5sum_a
-    
+
     # 2. Determine v2.0 input's AssayType and derive output AssayType
     v2_assay_type = v2_adat.header_metadata.get('AssayType', '')
     # Adding array to any v2.0 type always results in Mixed (unless v2.0 was Array-only)
@@ -289,47 +295,59 @@ def _merge_bridged_array_and_v2(
         output_assay_type = 'Array'
     else:
         output_assay_type = 'Mixed'
-    
+
     # 3. MedNorm validation based on ProcessSteps
     array_has_mednorm = MedNormValidator.has_mednorm_ext(raw_array.header_metadata)
     v2_has_mednorm = MedNormValidator.has_mednorm_ext_v2(v2_adat.header_metadata)
-    
+
     if array_has_mednorm and v2_has_mednorm:
         mednorm_ref_source = MedNormValidator.validate_with_v2(
             raw_array, v2_adat, med_norm_ref=med_norm_ref
         )
     else:
         mednorm_ref_source = None
-    
+
     # 4. Convert array source to v2.0
-    array_ctx = ArrayConversionContext.from_adat(raw_array, source_file_md5sum=md5_array)
+    array_ctx = ArrayConversionContext.from_adat(
+        raw_array, source_file_md5sum=md5_array
+    )
     array_ctx.source_file_id = '1'
     array_ctx.process_steps_id = '1'
     array_ctx.report_config_id = '1'
-    
+
     validate_source_array_adat(raw_array)
-    array_header_v2 = convert_array_header(raw_array, array_ctx, assay_type=output_assay_type)
-    array_columns_v2 = convert_array_col_data(raw_array, calibrator_id=array_ctx.calibrator_id)
+    array_header_v2 = convert_array_header(
+        raw_array, array_ctx, assay_type=output_assay_type
+    )
+    array_columns_v2 = convert_array_col_data(
+        raw_array, calibrator_id=array_ctx.calibrator_id
+    )
     array_index_v2 = convert_array_row_data(raw_array, array_ctx)
-    
+
     array_intermediate = AdatClass(
         data=raw_array.values,
         index=array_index_v2,
         columns=array_columns_v2,
         header_metadata=array_header_v2,
     )
-    
+
     # 5. Remap v2 ADAT row index *Id levels to match assigned context IDs
     # The v2 input's row index stores SourceFileId/ProcessStepsId/ReportConfigId
     # from its original header keys. We assign it new IDs ('2', '2', '2') in v2_ctx,
     # so we must remap the index levels to match.
-    v2_ctx = V2SourceContext(source_file_id='2', process_steps_id='2', report_config_id='2')
-    
+    v2_ctx = V2SourceContext(
+        source_file_id='2', process_steps_id='2', report_config_id='2'
+    )
+
     # Build mapping from v2's original keys to the new IDs we're assigning
     v2_original_sf_keys = list((v2_adat.header_metadata.get('SourceFile') or {}).keys())
-    v2_original_ps_keys = list((v2_adat.header_metadata.get('ProcessSteps') or {}).keys())
-    v2_original_rc_keys = list((v2_adat.header_metadata.get('ReportConfig') or {}).keys())
-    
+    v2_original_ps_keys = list(
+        (v2_adat.header_metadata.get('ProcessSteps') or {}).keys()
+    )
+    v2_original_rc_keys = list(
+        (v2_adat.header_metadata.get('ReportConfig') or {}).keys()
+    )
+
     id_mapping: dict[str, str] = {}
     for old_key in v2_original_sf_keys:
         id_mapping[old_key] = v2_ctx.source_file_id
@@ -337,16 +355,16 @@ def _merge_bridged_array_and_v2(
         id_mapping[old_key] = v2_ctx.process_steps_id
     for old_key in v2_original_rc_keys:
         id_mapping[old_key] = v2_ctx.report_config_id
-    
+
     v2_index_remapped = remap_row_index_ids(v2_adat.index, id_mapping)
-    
+
     # 6. Compute SeqId union with correct argument ordering
     # compute_seqid_union expects array-first + ngs-second and applies array-prefers
     # COL_DATA rules. When v2_adat contains Array rows, we need to ensure array rows
     # come first in both arguments and final output.
-    
+
     v2_readouts = set(v2_adat.index.get_level_values('SampleReadout'))
-    
+
     if output_assay_type == 'Array' or v2_readouts == {'NGS'}:
         # Simple case: array_intermediate is array, v2_adat is NGS (or both array)
         # Order is correct: array first, NGS second
@@ -357,36 +375,36 @@ def _merge_bridged_array_and_v2(
         # v2_adat is Mixed: contains both Array and NGS rows
         # We need to split v2 by SampleReadout, merge the array parts first,
         # then merge with NGS parts to maintain array-first order
-        
+
         v2_array_mask = v2_adat.index.get_level_values('SampleReadout') == 'Array'
         v2_ngs_mask = ~v2_array_mask
-        
+
         v2_array_part = v2_adat[v2_array_mask]
         v2_ngs_part = v2_adat[v2_ngs_mask]
-        
+
         v2_array_index = v2_index_remapped[v2_array_mask]
         v2_ngs_index = v2_index_remapped[v2_ngs_mask]
-        
+
         # Merge array parts: array_intermediate + v2_array_part
         # Use simple concatenation since both are array data
         array_seqids = list(array_intermediate.columns.get_level_values('SeqId'))
         v2_array_seqids = list(v2_array_part.columns.get_level_values('SeqId'))
         union_array_seqids = sorted(set(array_seqids) | set(v2_array_seqids))
-        
+
         array_df = pd.DataFrame(
             array_intermediate.values,
             index=array_intermediate.index,
             columns=array_seqids,
         ).reindex(columns=union_array_seqids)
-        
+
         v2_array_df = pd.DataFrame(
             v2_array_part.values,
             index=v2_array_part.index,
             columns=v2_array_seqids,
         ).reindex(columns=union_array_seqids)
-        
+
         combined_array_df = pd.concat([array_df, v2_array_df], axis=0)
-        
+
         # For COL_DATA, prefer array_intermediate values for shared SeqIds
         # (similar to compute_seqid_union's array-prefers logic)
         combined_array_columns = _merge_col_data(
@@ -395,7 +413,7 @@ def _merge_bridged_array_and_v2(
             union_array_seqids,
             mednorm_ref_source=None,
         )
-        
+
         # Build combined array Adat
         combined_array = AdatClass(
             data=combined_array_df.values,
@@ -403,28 +421,32 @@ def _merge_bridged_array_and_v2(
             columns=combined_array_columns,
             header_metadata={},
         )
-        
+
         # Now merge combined array with NGS part using compute_seqid_union
         rfu_df, merged_columns = compute_seqid_union(
             combined_array, v2_ngs_part, mednorm_ref_source=mednorm_ref_source
         )
-        
+
         # Update row indexes to reflect the split
         array_index_v2 = combined_array.index
         v2_index_remapped = v2_ngs_index
-    
+
     # 7. Merge headers
     if output_assay_type == 'Array':
-        merged_header = HeaderMerger.merge_array_headers(array_header_v2, v2_adat.header_metadata, array_ctx, v2_ctx)
+        merged_header = HeaderMerger.merge_array_headers(
+            array_header_v2, v2_adat.header_metadata, array_ctx, v2_ctx
+        )
     else:
         merged_header = merge_mixed_headers(
             array_header_v2, v2_adat.header_metadata, array_ctx, v2_ctx
         )
-    
+
     # 8. Align row indexes and concatenate
-    array_index_v2, v2_index_remapped = align_row_indexes(array_index_v2, v2_index_remapped)
+    array_index_v2, v2_index_remapped = align_row_indexes(
+        array_index_v2, v2_index_remapped
+    )
     merged_index = array_index_v2.append(v2_index_remapped)
-    
+
     # 9. Assemble result
     result = AdatClass(
         data=rfu_df.values,
@@ -432,13 +454,13 @@ def _merge_bridged_array_and_v2(
         columns=merged_columns,
         header_metadata=merged_header,
     )
-    
+
     if not validate_v2_header_fields(merged_header):
         raise ConversionError(
             'Merged header metadata is not compliant with the v2.0 closed field set. '
             'See logged warnings above for details.'
         )
-    
+
     return result
 
 
@@ -451,7 +473,7 @@ def _merge_ngs_and_v2(
     med_norm_ref: str | None,
 ) -> Adat:
     """Merge a native NGS ADAT and an existing v2.0 ADAT into a Mixed or NGS v2.0 output.
-    
+
     Output AssayType depends on v2.0's content:
     - If v2.0 is NGS-only → output is NGS
     - Otherwise → output is Mixed
@@ -464,53 +486,59 @@ def _merge_ngs_and_v2(
     else:
         raw_ngs, v2_adat = adat_b, adat_a
         md5_ngs, md5_v2 = md5sum_b, md5sum_a
-    
+
     # 2. Determine output AssayType based on v2.0's content
     v2_assay_type = v2_adat.header_metadata.get('AssayType', '')
     if v2_assay_type == 'NGS':
         output_assay_type = 'NGS'
     else:
         output_assay_type = 'Mixed'
-    
+
     # 3. MedNorm validation based on ProcessSteps
     ngs_has_mednorm = MedNormValidator.has_mednorm_ext(raw_ngs.header_metadata)
     v2_has_mednorm = MedNormValidator.has_mednorm_ext_v2(v2_adat.header_metadata)
-    
+
     if ngs_has_mednorm and v2_has_mednorm:
         mednorm_ref_source = MedNormValidator.validate_with_v2(
             raw_ngs, v2_adat, med_norm_ref=med_norm_ref
         )
     else:
         mednorm_ref_source = None
-    
+
     # 4. Convert NGS source to v2.0
     ngs_ctx = NGSConversionContext.from_adat(raw_ngs, source_file_md5sum=md5_ngs)
     ngs_ctx.source_file_id = '1'
     ngs_ctx.process_steps_id = '1'
-    
+
     validate_source_ngs_adat(raw_ngs)
     ngs_header_v2 = convert_ngs_header(raw_ngs, ngs_ctx, assay_type=output_assay_type)
     ngs_columns_v2 = convert_ngs_col_data(raw_ngs)
     ngs_index_v2 = convert_ngs_row_data(raw_ngs, ngs_ctx)
-    
+
     ngs_intermediate = AdatClass(
         data=raw_ngs.values,
         index=ngs_index_v2,
         columns=ngs_columns_v2,
         header_metadata=ngs_header_v2,
     )
-    
+
     # 5. Remap v2 ADAT row index *Id levels to match assigned context IDs
     # The v2 input's row index stores SourceFileId/ProcessStepsId/ReportConfigId
     # from its original header keys. We assign it new IDs ('2', '2', '2') in v2_ctx,
     # so we must remap the index levels to match.
-    v2_ctx = V2SourceContext(source_file_id='2', process_steps_id='2', report_config_id='2')
-    
+    v2_ctx = V2SourceContext(
+        source_file_id='2', process_steps_id='2', report_config_id='2'
+    )
+
     # Build mapping from v2's original keys to the new IDs we're assigning
     v2_original_sf_keys = list((v2_adat.header_metadata.get('SourceFile') or {}).keys())
-    v2_original_ps_keys = list((v2_adat.header_metadata.get('ProcessSteps') or {}).keys())
-    v2_original_rc_keys = list((v2_adat.header_metadata.get('ReportConfig') or {}).keys())
-    
+    v2_original_ps_keys = list(
+        (v2_adat.header_metadata.get('ProcessSteps') or {}).keys()
+    )
+    v2_original_rc_keys = list(
+        (v2_adat.header_metadata.get('ReportConfig') or {}).keys()
+    )
+
     id_mapping: dict[str, str] = {}
     for old_key in v2_original_sf_keys:
         id_mapping[old_key] = v2_ctx.source_file_id
@@ -518,15 +546,15 @@ def _merge_ngs_and_v2(
         id_mapping[old_key] = v2_ctx.process_steps_id
     for old_key in v2_original_rc_keys:
         id_mapping[old_key] = v2_ctx.report_config_id
-    
+
     v2_index_remapped = remap_row_index_ids(v2_adat.index, id_mapping)
-    
+
     # 6. Compute SeqId union with correct argument ordering
     # compute_seqid_union expects array-first + ngs-second. When v2_adat contains
     # Array rows, we need to split it and ensure array rows come first.
-    
+
     v2_readouts = set(v2_adat.index.get_level_values('SampleReadout'))
-    
+
     if output_assay_type == 'NGS':
         # Both inputs are NGS-only: use compute_seqid_union normally
         # (parameter names are misleading but function works for same-type merges)
@@ -543,37 +571,37 @@ def _merge_ngs_and_v2(
         # v2 contains Array rows (could be Array-only or Mixed)
         # compute_seqid_union needs array-first ordering, so we must split v2
         # and call it with array rows first, NGS rows second
-        
+
         v2_array_mask = v2_adat.index.get_level_values('SampleReadout') == 'Array'
         v2_ngs_mask = ~v2_array_mask
-        
+
         v2_array_part = v2_adat[v2_array_mask]
         v2_ngs_part = v2_adat[v2_ngs_mask] if v2_ngs_mask.any() else None
-        
+
         v2_array_index = v2_index_remapped[v2_array_mask]
         v2_ngs_index = v2_index_remapped[v2_ngs_mask] if v2_ngs_mask.any() else None
-        
+
         if v2_ngs_part is not None and len(v2_ngs_part) > 0:
             # v2 is Mixed: has both Array and NGS rows
             # Merge NGS parts first (ngs_intermediate + v2_ngs_part)
             ngs_seqids = list(ngs_intermediate.columns.get_level_values('SeqId'))
             v2_ngs_seqids = list(v2_ngs_part.columns.get_level_values('SeqId'))
             union_ngs_seqids = sorted(set(ngs_seqids) | set(v2_ngs_seqids))
-            
+
             ngs_df = pd.DataFrame(
                 ngs_intermediate.values,
                 index=ngs_intermediate.index,
                 columns=ngs_seqids,
             ).reindex(columns=union_ngs_seqids)
-            
+
             v2_ngs_df = pd.DataFrame(
                 v2_ngs_part.values,
                 index=v2_ngs_part.index,
                 columns=v2_ngs_seqids,
             ).reindex(columns=union_ngs_seqids)
-            
+
             combined_ngs_df = pd.concat([ngs_df, v2_ngs_df], axis=0)
-            
+
             # For COL_DATA, prefer ngs_intermediate values for shared SeqIds
             combined_ngs_columns = _merge_col_data(
                 ngs_intermediate.columns,
@@ -581,20 +609,20 @@ def _merge_ngs_and_v2(
                 union_ngs_seqids,
                 mednorm_ref_source=None,
             )
-            
+
             combined_ngs = AdatClass(
                 data=combined_ngs_df.values,
                 index=combined_ngs_df.index,
                 columns=combined_ngs_columns,
                 header_metadata={},
             )
-            
+
             # Now merge v2_array_part with combined_ngs using compute_seqid_union
             # (array first, NGS second)
             rfu_df, merged_columns = compute_seqid_union(
                 v2_array_part, combined_ngs, mednorm_ref_source=mednorm_ref_source
             )
-            
+
             # Update row indexes: array first (v2_array_index), then NGS (combined_ngs.index)
             ngs_index_v2 = combined_ngs.index
             v2_index_remapped = v2_array_index
@@ -614,7 +642,7 @@ def _merge_ngs_and_v2(
         rfu_df, merged_columns = compute_seqid_union(
             ngs_intermediate, v2_adat, mednorm_ref_source=mednorm_ref_source
         )
-    
+
     # 7. Merge headers
     if output_assay_type == 'Mixed':
         merged_header = merge_mixed_headers(
@@ -624,11 +652,11 @@ def _merge_ngs_and_v2(
         merged_header = HeaderMerger.merge_v2_headers(
             ngs_header_v2, v2_adat.header_metadata, 'NGS'
         )
-    
+
     # 8. Align row indexes and concatenate
     ngs_index_v2, v2_index_remapped = align_row_indexes(ngs_index_v2, v2_index_remapped)
     merged_index = ngs_index_v2.append(v2_index_remapped)
-    
+
     # 9. Assemble result
     result = AdatClass(
         data=rfu_df.values,
@@ -636,62 +664,62 @@ def _merge_ngs_and_v2(
         columns=merged_columns,
         header_metadata=merged_header,
     )
-    
+
     if not validate_v2_header_fields(merged_header):
         raise ConversionError(
             'Merged header metadata is not compliant with the v2.0 closed field set. '
             'See logged warnings above for details.'
         )
-    
+
     return result
 
 
 def _merge_native_arrays(
-    adat_a: Adat,
-    adat_b: Adat,
-    *,
-    md5sum_a: str | None,
-    md5sum_b: str | None
+    adat_a: Adat, adat_b: Adat, *, md5sum_a: str | None, md5sum_b: str | None
 ) -> Adat:
     """Merge two native array ADATs into an Array v2.0 output.
-    
+
     Both inputs must have the same AssayVersion. Converts both arrays to v2.0
     format, then merges them into an Array-type output.
     """
     # 1. Extract and validate AssayVersion
     header_a = getattr(adat_a, 'header_metadata', {})
     header_b = getattr(adat_b, 'header_metadata', {})
-    assay_version_a = header_a.get('!AssayVersion', '') or header_a.get('AssayVersion', '')
-    assay_version_b = header_b.get('!AssayVersion', '') or header_b.get('AssayVersion', '')
-    
+    assay_version_a = header_a.get('!AssayVersion', '') or header_a.get(
+        'AssayVersion', ''
+    )
+    assay_version_b = header_b.get('!AssayVersion', '') or header_b.get(
+        'AssayVersion', ''
+    )
+
     if assay_version_a != assay_version_b:
         raise AssayVersionError(
             f'Both array ADATs must have the same AssayVersion. '
             f'Got: {assay_version_a!r} and {assay_version_b!r}.'
         )
-    
+
     # 2. Build conversion contexts; assign source IDs for Array output
     ctx_a = ArrayConversionContext.from_adat(adat_a, source_file_md5sum=md5sum_a)
     ctx_a.source_file_id = '1'
     ctx_a.process_steps_id = '1'
     ctx_a.report_config_id = '1'
-    
+
     ctx_b = ArrayConversionContext.from_adat(adat_b, source_file_md5sum=md5sum_b)
     ctx_b.source_file_id = '2'
     ctx_b.process_steps_id = '2'
     ctx_b.report_config_id = '2'
-    
+
     # 3. Convert both arrays to v2.0 with assay_type='Array'
     validate_source_array_adat(adat_a)
     header_v2_a = convert_array_header(adat_a, ctx_a, assay_type='Array')
     columns_v2_a = convert_array_col_data(adat_a, calibrator_id=ctx_a.calibrator_id)
     index_v2_a = convert_array_row_data(adat_a, ctx_a)
-    
+
     validate_source_array_adat(adat_b)
     header_v2_b = convert_array_header(adat_b, ctx_b, assay_type='Array')
     columns_v2_b = convert_array_col_data(adat_b, calibrator_id=ctx_b.calibrator_id)
     index_v2_b = convert_array_row_data(adat_b, ctx_b)
-    
+
     # Assemble temporary intermediate Adats
     intermediate_a = AdatClass(
         data=adat_a.values,
@@ -705,19 +733,21 @@ def _merge_native_arrays(
         columns=columns_v2_b,
         header_metadata=header_v2_b,
     )
-    
+
     # 4. Compute SeqId union
     rfu_df, merged_columns = compute_seqid_union(
         intermediate_a, intermediate_b, mednorm_ref_source=None
     )
-    
+
     # 5. Merge headers (Array + Array → Array output)
-    merged_header = HeaderMerger.merge_array_headers(header_v2_a, header_v2_b, ctx_a, ctx_b)
-    
+    merged_header = HeaderMerger.merge_array_headers(
+        header_v2_a, header_v2_b, ctx_a, ctx_b
+    )
+
     # 6. Align row indexes and concatenate
     index_v2_a, index_v2_b = align_row_indexes(index_v2_a, index_v2_b)
     merged_index = index_v2_a.append(index_v2_b)
-    
+
     # 7. Assemble result
     result = AdatClass(
         data=rfu_df.values,
@@ -725,13 +755,13 @@ def _merge_native_arrays(
         columns=merged_columns,
         header_metadata=merged_header,
     )
-    
+
     if not validate_v2_header_fields(merged_header):
         raise ConversionError(
             'Merged array header metadata is not compliant with the v2.0 closed field set. '
             'See logged warnings above for details.'
         )
-    
+
     return result
 
 
@@ -744,7 +774,7 @@ def _merge_v2_combined_adats(
     med_norm_ref: str | None,
 ) -> Adat:
     """Merge two existing v2.0 ADATs into a single v2.0 output.
-    
+
     Both inputs are already in v2.0 format. Derive output AssayType from
     the union of SampleReadout values. For NGS-only pairs, validate that
     ProcessSteps are identical.
@@ -753,43 +783,45 @@ def _merge_v2_combined_adats(
     readout_a = set(adat_a.index.get_level_values('SampleReadout'))
     readout_b = set(adat_b.index.get_level_values('SampleReadout'))
     readout_union = readout_a | readout_b
-    
+
     if readout_union == {'Array'}:
         output_assay_type = 'Array'
     elif readout_union == {'NGS'}:
         output_assay_type = 'NGS'
     else:
         output_assay_type = 'Mixed'
-    
+
     # 2. For NGS-only pairs, validate ProcessSteps match
     if output_assay_type == 'NGS':
         validate_v2_ngs_process_steps(adat_a, adat_b)
-    
+
     # 3. MedNorm validation - check if both have MedNormExt
     a_has_mednorm = MedNormValidator.has_mednorm_ext_v2(adat_a.header_metadata)
     b_has_mednorm = MedNormValidator.has_mednorm_ext_v2(adat_b.header_metadata)
-    
+
     if a_has_mednorm and b_has_mednorm:
         mednorm_ref_source = MedNormValidator.validate_v2_pair(
             adat_a, adat_b, med_norm_ref=med_norm_ref
         )
     else:
         mednorm_ref_source = None
-    
+
     # 4. Compute SeqId union and merged COL_DATA
-    rfu_df, merged_columns = compute_seqid_union(adat_a, adat_b, mednorm_ref_source=mednorm_ref_source)
-    
+    rfu_df, merged_columns = compute_seqid_union(
+        adat_a, adat_b, mednorm_ref_source=mednorm_ref_source
+    )
+
     # 4. Merge headers - this renumbers SourceFile/ProcessSteps/ReportConfig keys
     merged_header = HeaderMerger.merge_v2_headers(
         adat_a.header_metadata,
         adat_b.header_metadata,
         output_assay_type,
     )
-    
+
     # 5. Remap row index *Id levels to match the renumbered header keys
     # HeaderMerger.merge_v2_headers renumbers keys sequentially (1, 2, 3, ...)
     # We need to build a mapping from original keys to new keys for both inputs
-    
+
     # Extract original keys from both inputs
     sf_a_keys = list((adat_a.header_metadata.get('SourceFile') or {}).keys())
     sf_b_keys = list((adat_b.header_metadata.get('SourceFile') or {}).keys())
@@ -797,12 +829,12 @@ def _merge_v2_combined_adats(
     ps_b_keys = list((adat_b.header_metadata.get('ProcessSteps') or {}).keys())
     rc_a_keys = list((adat_a.header_metadata.get('ReportConfig') or {}).keys())
     rc_b_keys = list((adat_b.header_metadata.get('ReportConfig') or {}).keys())
-    
+
     # Build mappings following HeaderMerger.merge_v2_headers logic (lines 571-612 in utils.py)
     # SourceFile keys are renumbered: a's keys → 1, 2, ...; b's keys → next, next+1, ...
     id_mapping_a: dict[str, str] = {}
     id_mapping_b: dict[str, str] = {}
-    
+
     # SourceFile mapping
     next_id = 1
     for old_key in sorted(sf_a_keys):
@@ -811,7 +843,7 @@ def _merge_v2_combined_adats(
     for old_key in sorted(sf_b_keys):
         id_mapping_b[old_key] = str(next_id)
         next_id += 1
-    
+
     # ProcessSteps mapping
     next_id = 1
     for old_key in sorted(ps_a_keys):
@@ -820,7 +852,7 @@ def _merge_v2_combined_adats(
     for old_key in sorted(ps_b_keys):
         id_mapping_b[old_key] = str(next_id)
         next_id += 1
-    
+
     # ReportConfig mapping
     next_id = 1
     for old_key in sorted(rc_a_keys):
@@ -829,15 +861,17 @@ def _merge_v2_combined_adats(
     for old_key in sorted(rc_b_keys):
         id_mapping_b[old_key] = str(next_id)
         next_id += 1
-    
+
     # Remap both row indexes
     index_a_remapped = remap_row_index_ids(adat_a.index, id_mapping_a)
     index_b_remapped = remap_row_index_ids(adat_b.index, id_mapping_b)
-    
+
     # 6. Align row indexes and concatenate
-    aligned_index_a, aligned_index_b = align_row_indexes(index_a_remapped, index_b_remapped)
+    aligned_index_a, aligned_index_b = align_row_indexes(
+        index_a_remapped, index_b_remapped
+    )
     merged_index = aligned_index_a.append(aligned_index_b)
-    
+
     # 6. Assemble result
     result = AdatClass(
         data=rfu_df.values,
@@ -845,13 +879,13 @@ def _merge_v2_combined_adats(
         columns=merged_columns,
         header_metadata=merged_header,
     )
-    
+
     if not validate_v2_header_fields(merged_header):
         raise ConversionError(
             'Merged v2.0 header metadata is not compliant with the v2.0 closed field set. '
             'See logged warnings above for details.'
         )
-    
+
     return result
 
 

--- a/somadata/conversion/merge.py
+++ b/somadata/conversion/merge.py
@@ -440,10 +440,10 @@ def _merge_col_data(
 def _build_seqid_lookup(columns: pd.MultiIndex) -> dict[str, dict[str, str]]:
     """Return ``{seq_id: {level_name: value}}`` for a COL_DATA MultiIndex."""
     seq_ids = columns.get_level_values('SeqId')
-    
+
     # Extract all level values upfront
     level_arrays = [columns.get_level_values(name) for name in columns.names]
-    
+
     # Build lookup dict: iterate once over SeqIds, once over levels
     result: dict[str, dict[str, str]] = {}
     for i, seq_id in enumerate(seq_ids):

--- a/somadata/conversion/ngs/header.py
+++ b/somadata/conversion/ngs/header.py
@@ -21,7 +21,6 @@ from somadata.conversion._helpers import (
     parse_process_steps,
     strip_bang_prefix,
 )
-
 from somadata.io.adat.v2_fields import V2_HEADER_FIELD_TYPES
 
 if TYPE_CHECKING:

--- a/somadata/conversion/ngs/row_data.py
+++ b/somadata/conversion/ngs/row_data.py
@@ -129,24 +129,22 @@ def _derive_med_norm_status(scale_factors: list[str]) -> str:
 
 
 def _derive_med_norm_status_vectorized(
-    field_names: list[str],
-    out_levels: dict[str, list],
-    n_rows: int
+    field_names: list[str], out_levels: dict[str, list], n_rows: int
 ) -> list[str]:
     """Vectorized MedNorm status derivation for all rows.
-    
+
     All scale factors for a row must be numeric and in [0.4, 2.5] for PASS.
     """
     result = [''] * n_rows
-    
+
     if not field_names:
         return result
-    
+
     # Build matrix of scale factor values (rows × fields)
     scale_matrix = []
     for field_name in field_names:
         scale_matrix.append(out_levels[field_name])
-    
+
     # Process each row
     for i in range(n_rows):
         values = [scale_matrix[j][i] for j in range(len(field_names))]
@@ -154,17 +152,17 @@ def _derive_med_norm_status_vectorized(
         values = [v for v in values if v]
         if not values:
             continue
-        
+
         try:
             floats = [float(v) for v in values]
         except (ValueError, TypeError):
             continue
-        
+
         if all(0.4 <= f <= 2.5 for f in floats):
             result[i] = 'PASS'
         else:
             result[i] = 'FLAG'
-    
+
     return result
 
 
@@ -225,7 +223,7 @@ def convert_ngs_row_data(
     # 2. New generated fields (one value per row)
     # ------------------------------------------------------------------
     out_levels['SampleReadout'] = ['NGS'] * n_rows
-    
+
     # GUID generation optimization: only generate for missing/blank keys
     if 'UniqueSampleKey' in out_levels:
         existing_keys = out_levels['UniqueSampleKey']
@@ -235,7 +233,7 @@ def convert_ngs_row_data(
         ]
     else:
         out_levels['UniqueSampleKey'] = [generate_guid() for _ in range(n_rows)]
-    
+
     out_levels['SourceFileId'] = [ctx.source_file_id] * n_rows
     out_levels['ProcessStepsId'] = [ctx.process_steps_id] * n_rows
 

--- a/somadata/conversion/utils.py
+++ b/somadata/conversion/utils.py
@@ -25,10 +25,10 @@ logger = logging.getLogger(__name__)
 
 class V2SourceContext:
     """Lightweight context for v2.0 ADAT sources in merge operations.
-    
+
     Used when merging a pre-conversion ADAT with an existing v2.0 ADAT to
     provide consistent source identifiers for header merging.
-    
+
     Attributes
     ----------
     source_file_id : str
@@ -38,7 +38,7 @@ class V2SourceContext:
     report_config_id : str
         ReportConfig identifier.
     """
-    
+
     def __init__(
         self,
         source_file_id: str = '1',
@@ -57,16 +57,16 @@ class V2SourceContext:
 
 class MedNormValidator:
     """Utilities for validating MedNorm compatibility between ADATs."""
-    
+
     @staticmethod
     def get_mednorm_ext_vectors(adat: Adat) -> dict[str, dict[str, str]]:
         """Extract Ref.MedNormExt.* column values keyed by (field, SeqId).
-        
+
         Parameters
         ----------
         adat : Adat
             Source ADAT.
-        
+
         Returns
         -------
         dict
@@ -75,12 +75,12 @@ class MedNormValidator:
         columns = getattr(adat, 'columns', None)
         if columns is None or not hasattr(columns, 'names'):
             return {}
-        
+
         result: dict[str, dict[str, str]] = {}
         seq_id_level = None
         if 'SeqId' in columns.names:
             seq_id_level = columns.get_level_values('SeqId')
-        
+
         for name in columns.names:
             if name.startswith('Ref.MedNormExt.'):
                 values = columns.get_level_values(name)
@@ -90,18 +90,18 @@ class MedNormValidator:
                     }
                 else:
                     result[name] = {}
-        
+
         return result
-    
+
     @staticmethod
     def get_mednorm_id_set(adat: Adat) -> set[str]:
         """Return the set of Ref.MedNorm.Id values present in COL_DATA.
-        
+
         Parameters
         ----------
         adat : Adat
             Source ADAT.
-        
+
         Returns
         -------
         set[str]
@@ -111,38 +111,38 @@ class MedNormValidator:
         if columns is None or 'Ref.MedNorm.Id' not in columns.names:
             return set()
         return set(str(v) for v in columns.get_level_values('Ref.MedNorm.Id') if v)
-    
+
     @staticmethod
     def has_mednorm_ext(header: dict) -> bool:
         """Check if ProcessSteps contains MedNormExt (pre-conversion format).
-        
+
         Parameters
         ----------
         header : dict
             Pre-conversion header metadata (ProcessSteps is a string).
-        
+
         Returns
         -------
         bool
             True if ProcessSteps contains 'MedNormExt'.
         """
         from somadata.conversion._helpers import lookup_header, parse_process_steps
-        
+
         raw = lookup_header(header, 'ProcessSteps')
         if not raw:
             return False
         steps = parse_process_steps(raw)
         return 'MedNormExt' in steps
-    
+
     @staticmethod
     def has_mednorm_ext_v2(header: dict) -> bool:
         """Check if ProcessSteps contains MedNormExt (v2.0 format).
-        
+
         Parameters
         ----------
         header : dict
             v2.0 header metadata (ProcessSteps is a dict).
-        
+
         Returns
         -------
         bool
@@ -155,7 +155,7 @@ class MedNormValidator:
             if 'MedNormExt' in steps_str:
                 return True
         return False
-    
+
     @staticmethod
     def validate_with_v2(
         raw_adat: Adat,
@@ -163,7 +163,7 @@ class MedNormValidator:
         med_norm_ref: str | None,
     ) -> Literal['array', 'ngs'] | None:
         """Validate MedNorm compatibility between a pre-conversion and v2.0 ADAT.
-        
+
         Parameters
         ----------
         raw_adat : Adat
@@ -172,12 +172,12 @@ class MedNormValidator:
             v2.0 ADAT.
         med_norm_ref : str or None
             MedNorm reference override identifier.
-        
+
         Returns
         -------
         Literal['array', 'ngs'] or None
             Which source's Ref.MedNormExt values to use, or None if identical.
-        
+
         Raises
         ------
         MedNormMismatchError
@@ -185,29 +185,29 @@ class MedNormValidator:
         """
         from somadata.conversion.detection import InputType, detect_input_type
         from somadata.conversion.errors import MedNormMismatchError
-        
+
         raw_vecs = MedNormValidator.get_mednorm_ext_vectors(raw_adat)
         v2_vecs = MedNormValidator.get_mednorm_ext_vectors(v2_adat)
-        
+
         shared_fields = set(raw_vecs) & set(v2_vecs)
         if not shared_fields:
             return None
-        
+
         raw_cols = getattr(raw_adat, 'columns', None)
         v2_cols = getattr(v2_adat, 'columns', None)
         if raw_cols is None or v2_cols is None:
             return None
-        
+
         if 'SeqId' in raw_cols.names and 'SeqId' in v2_cols.names:
             raw_seqids = set(raw_cols.get_level_values('SeqId'))
             v2_seqids = set(v2_cols.get_level_values('SeqId'))
             shared_seqids = raw_seqids & v2_seqids
         else:
             return None
-        
+
         if not shared_seqids:
             return None
-        
+
         mismatches: list[str] = []
         for field in sorted(shared_fields):
             for seq_id in sorted(shared_seqids):
@@ -217,37 +217,47 @@ class MedNormValidator:
                     mismatches.append(
                         f'{field}[{seq_id}]: raw={raw_val!r} vs v2={v2_val!r}'
                     )
-        
+
         if not mismatches:
             return None
-        
+
         if med_norm_ref is not None:
             raw_ids = MedNormValidator.get_mednorm_id_set(raw_adat)
             v2_ids = MedNormValidator.get_mednorm_id_set(v2_adat)
-            
+
             raw_type = detect_input_type(raw_adat)
-            
+
             if med_norm_ref in raw_ids:
-                source_name = 'array' if raw_type in (InputType.BRIDGED_ARRAY, InputType.NATIVE_ARRAY) else 'ngs'
+                source_name = (
+                    'array'
+                    if raw_type in (InputType.BRIDGED_ARRAY, InputType.NATIVE_ARRAY)
+                    else 'ngs'
+                )
                 logger.info(
                     'Ref.MedNormExt mismatch resolved by med_norm_ref=%r (%s source)',
-                    med_norm_ref, source_name
+                    med_norm_ref,
+                    source_name,
                 )
                 return source_name
             if med_norm_ref in v2_ids:
-                source_name = 'ngs' if raw_type in (InputType.BRIDGED_ARRAY, InputType.NATIVE_ARRAY) else 'array'
+                source_name = (
+                    'ngs'
+                    if raw_type in (InputType.BRIDGED_ARRAY, InputType.NATIVE_ARRAY)
+                    else 'array'
+                )
                 logger.info(
                     'Ref.MedNormExt mismatch resolved by med_norm_ref=%r (v2 source as %s)',
-                    med_norm_ref, source_name
+                    med_norm_ref,
+                    source_name,
                 )
                 return source_name
-            
+
             raise MedNormMismatchError(
                 f'med_norm_ref={med_norm_ref!r} does not match any Ref.MedNorm.Id '
                 f'value in either source. '
                 f'Raw IDs: {sorted(raw_ids)!r}. v2.0 IDs: {sorted(v2_ids)!r}.'
             )
-        
+
         detail = '\n  '.join(mismatches[:10])
         if len(mismatches) > 10:
             detail += f'\n  ... and {len(mismatches) - 10} more'
@@ -256,7 +266,7 @@ class MedNormValidator:
             f'Mismatches ({len(mismatches)} total):\n  {detail}\n'
             f'Provide med_norm_ref to override.'
         )
-    
+
     @staticmethod
     def validate_v2_pair(
         adat_a: Adat,
@@ -264,7 +274,7 @@ class MedNormValidator:
         med_norm_ref: str | None,
     ) -> Literal['array', 'ngs'] | None:
         """Validate MedNorm compatibility between two v2.0 ADATs.
-        
+
         Parameters
         ----------
         adat_a : Adat
@@ -273,41 +283,41 @@ class MedNormValidator:
             Second v2.0 ADAT.
         med_norm_ref : str or None
             MedNorm reference override identifier.
-        
+
         Returns
         -------
         Literal['array', 'ngs'] or None
             Which source's Ref.MedNormExt values to use, or None if identical.
-        
+
         Raises
         ------
         MedNormMismatchError
             If Ref.MedNormExt vectors are incompatible.
         """
         from somadata.conversion.errors import MedNormMismatchError
-        
+
         vecs_a = MedNormValidator.get_mednorm_ext_vectors(adat_a)
         vecs_b = MedNormValidator.get_mednorm_ext_vectors(adat_b)
-        
+
         shared_fields = set(vecs_a) & set(vecs_b)
         if not shared_fields:
             return None
-        
+
         cols_a = getattr(adat_a, 'columns', None)
         cols_b = getattr(adat_b, 'columns', None)
         if cols_a is None or cols_b is None:
             return None
-        
+
         if 'SeqId' in cols_a.names and 'SeqId' in cols_b.names:
             seqids_a = set(cols_a.get_level_values('SeqId'))
             seqids_b = set(cols_b.get_level_values('SeqId'))
             shared_seqids = seqids_a & seqids_b
         else:
             return None
-        
+
         if not shared_seqids:
             return None
-        
+
         mismatches: list[str] = []
         for field in sorted(shared_fields):
             for seq_id in sorted(shared_seqids):
@@ -317,14 +327,14 @@ class MedNormValidator:
                     mismatches.append(
                         f'{field}[{seq_id}]: source_a={val_a!r} vs source_b={val_b!r}'
                     )
-        
+
         if not mismatches:
             return None
-        
+
         if med_norm_ref is not None:
             ids_a = MedNormValidator.get_mednorm_id_set(adat_a)
             ids_b = MedNormValidator.get_mednorm_id_set(adat_b)
-            
+
             if med_norm_ref in ids_a:
                 logger.info(
                     'Ref.MedNormExt mismatch resolved by med_norm_ref=%r (first source)',
@@ -337,13 +347,13 @@ class MedNormValidator:
                     med_norm_ref,
                 )
                 return 'ngs'
-            
+
             raise MedNormMismatchError(
                 f'med_norm_ref={med_norm_ref!r} does not match any Ref.MedNorm.Id '
                 f'value in either source. '
                 f'Source A IDs: {sorted(ids_a)!r}. Source B IDs: {sorted(ids_b)!r}.'
             )
-        
+
         detail = '\n  '.join(mismatches[:10])
         if len(mismatches) > 10:
             detail += f'\n  ... and {len(mismatches) - 10} more'
@@ -361,32 +371,32 @@ class MedNormValidator:
 
 def validate_v2_ngs_process_steps(adat_a: Adat, adat_b: Adat) -> None:
     """Validate that two v2.0 NGS-only ADATs have identical ProcessSteps.
-    
+
     For NGS-only pairs, both sources must have the same ProcessSteps entries.
-    
+
     Parameters
     ----------
     adat_a : Adat
         First v2.0 NGS ADAT.
     adat_b : Adat
         Second v2.0 NGS ADAT.
-    
+
     Raises
     ------
     ProcessStepsMismatchError
         If ProcessSteps are not identical.
     """
     from somadata.conversion.errors import ProcessStepsMismatchError
-    
+
     ps_a = adat_a.header_metadata.get('ProcessSteps', {})
     ps_b = adat_b.header_metadata.get('ProcessSteps', {})
-    
+
     if not isinstance(ps_a, dict) or not isinstance(ps_b, dict):
         return
-    
+
     steps_a = sorted(ps_a.values())
     steps_b = sorted(ps_b.values())
-    
+
     if steps_a != steps_b:
         raise ProcessStepsMismatchError(
             f'NGS-only v2.0 pair requires identical ProcessSteps. '
@@ -403,7 +413,7 @@ def validate_v2_ngs_process_steps(adat_a: Adat, adat_b: Adat) -> None:
 
 class HeaderMerger:
     """Utilities for merging v2.0 headers from multiple sources."""
-    
+
     @staticmethod
     def merge_array_headers(
         header_a: dict,
@@ -412,9 +422,9 @@ class HeaderMerger:
         ctx_b,
     ) -> dict:
         """Merge two converted array v2.0 headers into Array output header.
-        
+
         Similar to merge_mixed_headers but output AssayType='Array'.
-        
+
         Parameters
         ----------
         header_a : dict
@@ -425,7 +435,7 @@ class HeaderMerger:
             Conversion context for first array (with source IDs).
         ctx_b : ArrayConversionContext or V2SourceContext
             Conversion context for second array (with source IDs).
-        
+
         Returns
         -------
         dict
@@ -437,19 +447,19 @@ class HeaderMerger:
             merge_plate_json,
         )
         from somadata.io.adat.v2_fields import V2_HEADER_FIELD_TYPES
-        
+
         out: dict = {key: '' for key in V2_HEADER_FIELD_TYPES}
-        
+
         out['FileVersion'] = '2.0'
         out['AssayType'] = 'Array'
         out['FileCreatedDate'] = datetime.datetime.now(datetime.timezone.utc).strftime(
             '%Y-%m-%dT%H:%M:%SZ'
         )
         out['AdatId'] = generate_guid()
-        
+
         if header_a.get('AssayVersion'):
             out['AssayVersion'] = header_a['AssayVersion']
-        
+
         sf_a = header_a.get('SourceFile') or {}
         sf_b = header_b.get('SourceFile') or {}
         merged_sf: dict = {}
@@ -458,7 +468,7 @@ class HeaderMerger:
         for _key, val in sf_b.items():
             merged_sf[ctx_b.source_file_id] = val
         out['SourceFile'] = merged_sf
-        
+
         ps_a = header_a.get('ProcessSteps') or {}
         ps_b = header_b.get('ProcessSteps') or {}
         merged_ps: dict = {}
@@ -467,7 +477,7 @@ class HeaderMerger:
         for _key, val in ps_b.items():
             merged_ps[ctx_b.process_steps_id] = val
         out['ProcessSteps'] = merged_ps
-        
+
         rc_a = header_a.get('ReportConfig') or {}
         rc_b = header_b.get('ReportConfig') or {}
         merged_rc: dict = {}
@@ -477,7 +487,7 @@ class HeaderMerger:
             merged_rc[ctx_b.report_config_id] = val
         if merged_rc:
             out['ReportConfig'] = merged_rc
-        
+
         _PIPE_FIELDS = (
             'Title',
             'StudyOrganism',
@@ -491,7 +501,7 @@ class HeaderMerger:
             )
             if merged:
                 out[field] = merged
-        
+
         _PLATE_JSON_FIELDS = (
             'PlateScaleScalar',
             'CalibrateTailPercent',
@@ -510,9 +520,9 @@ class HeaderMerger:
             merged_plates = merge_plate_json(dict_a, dict_b, field_name=field)
             if merged_plates:
                 out[field] = merged_plates
-        
+
         return out
-    
+
     @staticmethod
     def merge_v2_headers(
         header_a: dict,
@@ -520,10 +530,10 @@ class HeaderMerger:
         assay_type: str,
     ) -> dict:
         """Merge two v2.0 headers into a single v2.0 output header.
-        
+
         Simplified version of merge_mixed_headers for v2 + v2 case where both
         sources already have v2.0 structure.
-        
+
         Parameters
         ----------
         header_a : dict
@@ -532,7 +542,7 @@ class HeaderMerger:
             Second v2.0 header.
         assay_type : str
             Output AssayType ('Array', 'NGS', or 'Mixed').
-        
+
         Returns
         -------
         dict
@@ -544,28 +554,28 @@ class HeaderMerger:
             merge_plate_json,
         )
         from somadata.io.adat.v2_fields import V2_HEADER_FIELD_TYPES
-        
+
         out: dict = {key: '' for key in V2_HEADER_FIELD_TYPES}
-        
+
         out['FileVersion'] = '2.0'
         out['AssayType'] = assay_type
         out['FileCreatedDate'] = datetime.datetime.now(datetime.timezone.utc).strftime(
             '%Y-%m-%dT%H:%M:%SZ'
         )
         out['AdatId'] = generate_guid()
-        
+
         if header_a.get('AssayVersion'):
             out['AssayVersion'] = header_a['AssayVersion']
         elif header_b.get('AssayVersion'):
             out['AssayVersion'] = header_b['AssayVersion']
-        
+
         sf_a = header_a.get('SourceFile') or {}
         sf_b = header_b.get('SourceFile') or {}
         if not isinstance(sf_a, dict):
             sf_a = {}
         if not isinstance(sf_b, dict):
             sf_b = {}
-        
+
         merged_sf: dict = {}
         next_id = 1
         for _key, val in sorted(sf_a.items()):
@@ -575,14 +585,14 @@ class HeaderMerger:
             merged_sf[str(next_id)] = val
             next_id += 1
         out['SourceFile'] = merged_sf
-        
+
         ps_a = header_a.get('ProcessSteps') or {}
         ps_b = header_b.get('ProcessSteps') or {}
         if not isinstance(ps_a, dict):
             ps_a = {}
         if not isinstance(ps_b, dict):
             ps_b = {}
-        
+
         merged_ps: dict = {}
         next_id = 1
         for _key, val in sorted(ps_a.items()):
@@ -592,14 +602,14 @@ class HeaderMerger:
             merged_ps[str(next_id)] = val
             next_id += 1
         out['ProcessSteps'] = merged_ps
-        
+
         rc_a = header_a.get('ReportConfig') or {}
         rc_b = header_b.get('ReportConfig') or {}
         if not isinstance(rc_a, dict):
             rc_a = {}
         if not isinstance(rc_b, dict):
             rc_b = {}
-        
+
         merged_rc: dict = {}
         next_id = 1
         for _key, val in sorted(rc_a.items()):
@@ -610,7 +620,7 @@ class HeaderMerger:
             next_id += 1
         if merged_rc:
             out['ReportConfig'] = merged_rc
-        
+
         _PIPE_FIELDS = (
             'Title',
             'StudyOrganism',
@@ -624,7 +634,7 @@ class HeaderMerger:
             )
             if merged:
                 out[field] = merged
-        
+
         _PLATE_JSON_FIELDS = (
             'PlateScaleScalar',
             'CalibrateTailPercent',
@@ -643,17 +653,19 @@ class HeaderMerger:
             merged_plates = merge_plate_json(dict_a, dict_b, field_name=field)
             if merged_plates:
                 out[field] = merged_plates
-        
+
         reads_a = header_a.get('PlateSOMAmerNormReadsStatus') or {}
         reads_b = header_b.get('PlateSOMAmerNormReadsStatus') or {}
         if not isinstance(reads_a, dict):
             reads_a = {}
         if not isinstance(reads_b, dict):
             reads_b = {}
-        merged_reads = merge_plate_json(reads_a, reads_b, field_name='PlateSOMAmerNormReadsStatus')
+        merged_reads = merge_plate_json(
+            reads_a, reads_b, field_name='PlateSOMAmerNormReadsStatus'
+        )
         if merged_reads:
             out['PlateSOMAmerNormReadsStatus'] = merged_reads
-        
+
         return out
 
 
@@ -664,12 +676,12 @@ class HeaderMerger:
 
 def _split_by_sample_readout(adat: Adat) -> tuple[Adat | None, Adat | None]:
     """Split a v2.0 ADAT into Array and NGS parts by SampleReadout.
-    
+
     Parameters
     ----------
     adat : Adat
         v2.0 ADAT to split (may be Array-only, NGS-only, or Mixed).
-    
+
     Returns
     -------
     tuple[Adat | None, Adat | None]
@@ -677,9 +689,9 @@ def _split_by_sample_readout(adat: Adat) -> tuple[Adat | None, Adat | None]:
     """
     if 'SampleReadout' not in adat.index.names:
         return adat, None
-    
+
     readouts = set(adat.index.get_level_values('SampleReadout'))
-    
+
     if readouts == {'Array'}:
         return adat, None
     elif readouts == {'NGS'}:
@@ -697,7 +709,7 @@ def align_row_indexes(
     index_b: pd.MultiIndex,
 ) -> tuple[pd.MultiIndex, pd.MultiIndex]:
     """Return both MultiIndexes reordered to a shared, canonical level set.
-    
+
     Array and NGS row converters build their output MultiIndexes via
     insertion-order dicts, so the level ordering can differ even when both
     indexes carry stubs for the other platform's fields. This function
@@ -705,14 +717,14 @@ def align_row_indexes(
     then any ``index_b``-exclusive names appended), then reindexes each
     MultiIndex to that canonical set — inserting blank (empty-string) levels
     for any fields that a source does not have.
-    
+
     Parameters
     ----------
     index_a : pd.MultiIndex
         Row index from first source.
     index_b : pd.MultiIndex
         Row index from second source.
-    
+
     Returns
     -------
     tuple[pd.MultiIndex, pd.MultiIndex]
@@ -722,14 +734,14 @@ def align_row_indexes(
     """
     names_a = list(index_a.names)
     names_b = list(index_b.names)
-    
+
     seen: set[str] = set(names_a)
     canonical: list[str] = list(names_a)
     for name in names_b:
         if name not in seen:
             canonical.append(name)
             seen.add(name)
-    
+
     def _reorder(idx: pd.MultiIndex, ordered_names: list[str]) -> pd.MultiIndex:
         existing = set(idx.names)
         n = len(idx)
@@ -740,7 +752,7 @@ def align_row_indexes(
             else:
                 arrays.append([''] * n)
         return pd.MultiIndex.from_arrays(arrays, names=ordered_names)
-    
+
     return _reorder(index_a, canonical), _reorder(index_b, canonical)
 
 
@@ -749,11 +761,11 @@ def remap_row_index_ids(
     old_to_new_mapping: dict[str, str],
 ) -> pd.MultiIndex:
     """Remap SourceFileId, ProcessStepsId, and ReportConfigId levels to new header keys.
-    
+
     When merging headers, SourceFile/ProcessSteps/ReportConfig keys are renumbered.
     This function updates the corresponding *Id levels in the row index to match
     the new header structure.
-    
+
     Parameters
     ----------
     index : pd.MultiIndex
@@ -761,12 +773,12 @@ def remap_row_index_ids(
     old_to_new_mapping : dict[str, str]
         Mapping from old header keys to new header keys for each JSON field.
         Example: {'1': '2', '2': '3'} when renumbering IDs during merge.
-    
+
     Returns
     -------
     pd.MultiIndex
         A new MultiIndex with *Id levels remapped according to the mapping.
-    
+
     Examples
     --------
     >>> # After merge_v2_headers renumbers SourceFile keys from '1' to '1', '2' to '2'
@@ -775,10 +787,10 @@ def remap_row_index_ids(
     """
     id_levels = {'SourceFileId', 'ProcessStepsId', 'ReportConfigId'}
     remap_needed = id_levels & set(index.names)
-    
+
     if not remap_needed:
         return index
-    
+
     arrays: list[list] = []
     for name in index.names:
         level_values = list(index.get_level_values(name))
@@ -787,5 +799,5 @@ def remap_row_index_ids(
                 old_to_new_mapping.get(str(val), str(val)) for val in level_values
             ]
         arrays.append(level_values)
-    
+
     return pd.MultiIndex.from_arrays(arrays, names=index.names)

--- a/somadata/io/adat/file.py
+++ b/somadata/io/adat/file.py
@@ -8,9 +8,8 @@ import re
 import warnings
 from datetime import date, datetime
 from importlib.metadata import version
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Tuple, Union
 
-import numpy as np
 import pandas as pd
 
 from somadata import Adat
@@ -40,7 +39,7 @@ def _is_valid_iso8601_date(val: str) -> bool:
     because ``fromisoformat()`` only accepts ``Z`` natively on Python 3.11+,
     while this project requires Python 3.9+.
     """
-    normalised = val.replace('Z', '+00:00')
+    normalised = val[:-1] + '+00:00' if val.endswith('Z') else val
     for parser in (date.fromisoformat, datetime.fromisoformat):
         try:
             parser(normalised)
@@ -287,15 +286,8 @@ def _validate_v2_field_values(
                 bad_indices = list(non_missing.index[numeric.isna()])
 
             elif ftype is FieldType.DATE:
-                normalised = non_missing.str.replace('Z', '+00:00', regex=False)
-                parsed_date = pd.to_datetime(
-                    normalised, format='%Y-%m-%d', errors='coerce', utc=False
-                )
-                parsed_dt = pd.to_datetime(
-                    normalised, format='ISO8601', errors='coerce'
-                )
-                valid = parsed_date.notna() | parsed_dt.notna()
-                bad_indices = list(non_missing.index[~valid])
+                valid_mask = non_missing.str.strip().map(_is_valid_iso8601_date)
+                bad_indices = list(non_missing.index[~valid_mask])
 
             elif ftype is FieldType.JSON:
 
@@ -336,7 +328,7 @@ def read_adat(path_or_buf: Union[str, io.TextIOWrapper], *args, **kwargs) -> Ada
 
     For v2.0 ADATs (``FileVersion == "2.0"``), field values in ``^ROW_DATA``
     and ``^COL_DATA`` are validated against their declared v2.0 types.
-    Type mismatches produce warnings calls rather than errors.
+    Type mismatches are logged as warnings rather than raising errors.
 
     Parameters
     ----------

--- a/somadata/io/adat/file.py
+++ b/somadata/io/adat/file.py
@@ -6,11 +6,16 @@ import json
 import logging
 import re
 import warnings
+from datetime import date, datetime
 from importlib.metadata import version
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
+
+import numpy as np
+import pandas as pd
 
 from somadata import Adat
 from somadata.io.adat.errors import AdatReadError, AdatWriteError
+from somadata.io.adat.v2_fields import FieldType
 from somadata.io.adat.v2_fields import (
     serialize_header_value_v2 as _serialize_header_value_v2,
 )
@@ -20,6 +25,29 @@ from somadata.io.adat.v2_fields import (
     validate_v2_header_fields as _validate_v2_header_fields,
 )
 from somadata.tools.math import jround
+
+logger = logging.getLogger(__name__)
+
+
+def _is_valid_iso8601_date(val: str) -> bool:
+    """Return True if *val* is a valid ISO 8601 date or datetime string.
+
+    Accepts ``YYYY-MM-DD`` and ``YYYY-MM-DDTHH:MM:SS[Z]``.  Uses
+    ``datetime.fromisoformat()`` so calendar validity is enforced (e.g.
+    ``2026-02-30`` correctly returns False).
+
+    The trailing ``Z`` suffix is normalised to ``+00:00`` before parsing
+    because ``fromisoformat()`` only accepts ``Z`` natively on Python 3.11+,
+    while this project requires Python 3.9+.
+    """
+    normalised = val.replace('Z', '+00:00')
+    for parser in (date.fromisoformat, datetime.fromisoformat):
+        try:
+            parser(normalised)
+            return True
+        except ValueError:
+            continue
+    return False
 
 
 def parse_file(
@@ -197,8 +225,118 @@ def read_file(filepath: str) -> Adat:
     return read_adat(filepath)
 
 
+def _validate_v2_field_values(
+    row_metadata: Dict[str, List],
+    column_metadata: Dict[str, List],
+) -> None:
+    """Emit warnings for v2.0 field values that violate their declared type.
+
+    Called after parsing when ``FileVersion == "2.0"``.  Violations produce
+    ``warnings.warn`` calls (not exceptions) to remain lenient during early
+    adoption of the v2.0 format.
+
+    Detection is vectorized using pandas/numpy so that large COL_DATA sections
+    (thousands of analytes) are checked efficiently.  A single warning is
+    emitted per violating field, listing all offending indices, rather than
+    one warning per value.
+
+    Checks performed per FieldType:
+
+    - **Integer** — value must be a whole-number integer (or a recognised
+      missing-value sentinel: empty string, ``"NA"``, or ``"N/A"``).
+    - **Decimal** — value must be parseable as a float (or missing).
+    - **Date** — value must be a valid ISO 8601 date/datetime (or missing).
+    - **JSON** — value must be parseable as valid JSON (or be empty/missing).
+    - **String** — value must be ≤ 1 024 characters.
+
+    Parameters
+    ----------
+    row_metadata : dict
+        ``{field_name: [value, ...]}`` from ``parse_file``.
+    column_metadata : dict
+        ``{field_name: [value, ...]}`` from ``parse_file``.
+    """
+    _MISSING = {'', 'na', 'n/a'}
+
+    def _check_section(
+        metadata: Dict[str, List],
+        type_fn,
+        section: str,
+    ) -> None:
+        for field_name, values in metadata.items():
+            if not values:
+                continue
+
+            ftype = type_fn(field_name)
+            series = pd.Series(values, dtype=object).fillna('').astype(str)
+            missing_mask = series.str.strip().str.lower().isin(_MISSING)
+            non_missing = series[~missing_mask]
+
+            if non_missing.empty:
+                continue
+
+            bad_indices: list[int] = []
+
+            if ftype is FieldType.INTEGER:
+                numeric = pd.to_numeric(non_missing, errors='coerce')
+                bad_mask = numeric.isna() | (numeric % 1 != 0)
+                bad_indices = list(non_missing.index[bad_mask])
+
+            elif ftype is FieldType.DECIMAL:
+                numeric = pd.to_numeric(non_missing, errors='coerce')
+                bad_indices = list(non_missing.index[numeric.isna()])
+
+            elif ftype is FieldType.DATE:
+                normalised = non_missing.str.replace('Z', '+00:00', regex=False)
+                parsed_date = pd.to_datetime(
+                    normalised, format='%Y-%m-%d', errors='coerce', utc=False
+                )
+                parsed_dt = pd.to_datetime(
+                    normalised, format='ISO8601', errors='coerce'
+                )
+                valid = parsed_date.notna() | parsed_dt.notna()
+                bad_indices = list(non_missing.index[~valid])
+
+            elif ftype is FieldType.JSON:
+
+                def _invalid_json(v: str) -> bool:
+                    try:
+                        json.loads(v)
+                        return False
+                    except (json.JSONDecodeError, ValueError):
+                        return True
+
+                bad_mask = non_missing.map(_invalid_json)
+                bad_indices = list(non_missing.index[bad_mask])
+
+            elif ftype is FieldType.STRING:
+                bad_mask = non_missing.str.len() > 1024
+                bad_indices = list(non_missing.index[bad_mask])
+
+            if bad_indices:
+                sample = bad_indices[:5]
+                suffix = ', ...' if len(bad_indices) > 5 else ''
+                logger.warning(
+                    'v2.0 type violation in %s field "%s": '
+                    'expected %s, found %d invalid value(s) at indices %s%s.',
+                    section,
+                    field_name,
+                    ftype.value,
+                    len(bad_indices),
+                    sample,
+                    suffix,
+                )
+
+    _check_section(row_metadata, _v2_row_field_type, '^ROW_DATA')
+    _check_section(column_metadata, _v2_col_field_type, '^COL_DATA')
+
+
 def read_adat(path_or_buf: Union[str, io.TextIOWrapper], *args, **kwargs) -> Adat:
     """Returns an Adat from the filepath/name.
+
+    For v2.0 ADATs (``FileVersion == "2.0"``), field values in ``^ROW_DATA``
+    and ``^COL_DATA`` are validated against their declared v2.0 types.
+    Type mismatches produce warnings calls rather than errors.
 
     Parameters
     ----------
@@ -216,6 +354,9 @@ def read_adat(path_or_buf: Union[str, io.TextIOWrapper], *args, **kwargs) -> Ada
     rfu_matrix, row_metadata, column_metadata, header_metadata = parse_file(
         path_or_buf, *args, **kwargs
     )
+
+    if header_metadata.get('FileVersion') == '2.0':
+        _validate_v2_field_values(row_metadata, column_metadata)
 
     return Adat.from_features(
         rfu_matrix=rfu_matrix,

--- a/tests/io/adat/test_read_adat_v2.py
+++ b/tests/io/adat/test_read_adat_v2.py
@@ -1,0 +1,648 @@
+"""Tests for the v2.0 ADAT reader (Tasks 4.1 and 4.2).
+
+Task 4.1 — v2.0-aware reader dispatch:
+  - read_adat correctly parses v2.0 files (no ``!`` prefix on Name/Type rows)
+  - JSON header values parsed as dicts/lists, not raw strings
+  - Round-trip: write_adat(v2.0) → read_adat → structure preserved
+
+Task 4.2 — v2.0 field type validation on read:
+  - Integer fields: non-integer values log a warning
+  - Decimal fields: non-numeric values log a warning
+  - Date fields: non-ISO-8601 values log a warning
+  - JSON fields: invalid JSON logs a warning (COL_DATA context)
+  - String fields: values >1024 chars log a warning
+  - Missing values (empty string, "NA", "N/A") are silently accepted for all types
+  - Clean v2.0 files produce no type-violation log warnings
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+
+import pandas as pd
+import pytest
+
+from somadata.adat import Adat
+from somadata.io.adat.file import read_adat, write_adat
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_minimal_v2_adat(
+    header: dict | None = None,
+    row_names: list[str] | None = None,
+    row_values: list[list] | None = None,
+    col_levels: dict[str, list] | None = None,
+) -> Adat:
+    """Build a minimal, spec-compliant v2.0 Adat for reader/roundtrip tests."""
+    default_header = {
+        'FileVersion': '2.0',
+        'AdatId': 'GID-test-reader-001',
+        'AssayType': 'Array',
+        'AssayVersion': 'v5.0',
+        'UseRestriction': 'Research Use Only',
+        'SourceFile': '',
+        'SOMAmerReferenceSource': '2025-04-10',
+        'FileCreatedDate': '2026-01-31',
+        'Title': 'Reader Test',
+        'StudyOrganism': 'Human',
+        'StudyMatrix': 'Plasma',
+        'ProcessSteps': {'1': ['Raw RFU', 'Hyb Normalization']},
+        'ReportConfig': '',
+        'PlateScaleScalar': '',
+        'CalibrateTailPercent': '',
+        'CalibrateTailPercentStatus': '',
+        'QCCheckTailPercent': '',
+        'QCCheckTailPercentStatus': '',
+        'PlateScaleStatus': '',
+        'PlateSOMAmerNormReadsStatus': '',
+    }
+    if header:
+        default_header.update(header)
+
+    row_names = row_names or ['SampleId', 'SampleType', 'PlateId']
+    row_values = row_values or [
+        ['S1', 'S2'],
+        ['Sample', 'Sample'],
+        ['PLT001', 'PLT001'],
+    ]
+
+    if col_levels is not None:
+        arrays = [col_levels[n] for n in col_levels]
+        col_index = pd.MultiIndex.from_arrays(arrays, names=list(col_levels.keys()))
+    else:
+        col_index = pd.MultiIndex.from_arrays(
+            [['10000-01', '10001-02']], names=['SeqId']
+        )
+
+    index = pd.MultiIndex.from_arrays(row_values, names=row_names)
+    n_samples = len(row_values[0])
+    n_analytes = len(col_index)
+    data = [[1000.0] * n_analytes for _ in range(n_samples)]
+    return Adat(
+        data=data, index=index, columns=col_index, header_metadata=default_header
+    )
+
+
+def _roundtrip(adat: Adat) -> Adat:
+    """Write then read back an Adat."""
+    buf = io.StringIO()
+    write_adat(adat, buf)
+    buf.seek(0)
+    return read_adat(buf)
+
+
+# ---------------------------------------------------------------------------
+# Task 4.1: v2.0-aware reader dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestV2ReaderDispatch:
+    def test_fileversion_parsed_as_string(self):
+        """FileVersion header value must survive roundtrip as a plain string."""
+        adat = _make_minimal_v2_adat()
+        rt = _roundtrip(adat)
+        assert rt.header_metadata.get('FileVersion') == '2.0'
+
+    def test_header_preserved_on_roundtrip(self):
+        adat = _make_minimal_v2_adat(header={'AssayType': 'NGS'})
+        rt = _roundtrip(adat)
+        assert rt.header_metadata.get('AssayType') == 'NGS'
+
+    def test_json_header_dict_preserved(self):
+        """JSON-typed header fields round-trip as dicts (not raw strings)."""
+        ps = {'1': ['Raw RFU', 'Hyb Normalization']}
+        adat = _make_minimal_v2_adat(header={'ProcessSteps': ps})
+        rt = _roundtrip(adat)
+        assert rt.header_metadata.get('ProcessSteps') == ps
+
+    def test_json_header_dict_with_nested_values(self):
+        scalar = {'PLT001': {'PlatformSpecific': 1.04}}
+        adat = _make_minimal_v2_adat(header={'PlateScaleScalar': scalar})
+        rt = _roundtrip(adat)
+        assert rt.header_metadata.get('PlateScaleScalar') == scalar
+
+    def test_rfu_shape_preserved(self):
+        adat = _make_minimal_v2_adat()
+        rt = _roundtrip(adat)
+        assert rt.shape == adat.shape
+
+    def test_rfu_values_preserved(self):
+        adat = _make_minimal_v2_adat()
+        rt = _roundtrip(adat)
+        assert list(rt.values[0]) == list(adat.values[0])
+
+    def test_column_names_preserved(self):
+        adat = _make_minimal_v2_adat()
+        rt = _roundtrip(adat)
+        assert list(rt.columns.names) == list(adat.columns.names)
+
+    def test_row_names_preserved(self):
+        adat = _make_minimal_v2_adat()
+        rt = _roundtrip(adat)
+        assert list(rt.index.names) == list(adat.index.names)
+
+    def test_seqid_values_preserved(self):
+        adat = _make_minimal_v2_adat()
+        rt = _roundtrip(adat)
+        assert list(rt.columns.get_level_values('SeqId')) == list(
+            adat.columns.get_level_values('SeqId')
+        )
+
+    def test_row_metadata_values_preserved(self):
+        adat = _make_minimal_v2_adat()
+        rt = _roundtrip(adat)
+        assert list(rt.index.get_level_values('SampleId')) == list(
+            adat.index.get_level_values('SampleId')
+        )
+
+    def test_multi_level_col_metadata_preserved(self):
+        """Multiple COL_DATA levels survive write→read."""
+        adat = _make_minimal_v2_adat(
+            col_levels={
+                'SeqId': ['10000-01', '10001-02'],
+                'Target': ['ProteinA', 'ProteinB'],
+                'EntrezGeneId': ['8514', '3479'],
+            }
+        )
+        rt = _roundtrip(adat)
+        assert list(rt.columns.names) == ['SeqId', 'Target', 'EntrezGeneId']
+        assert list(rt.columns.get_level_values('Target')) == ['ProteinA', 'ProteinB']
+
+    def test_no_bang_prefix_in_col_data_on_write(self):
+        """v2.0 writer must not emit ``!Name`` / ``!Type`` in ^COL_DATA."""
+        buf = io.StringIO()
+        write_adat(_make_minimal_v2_adat(), buf)
+        content = buf.getvalue()
+        assert '!Name' not in content
+        assert '!Type' not in content
+
+    def test_no_checksum_line_on_write(self):
+        buf = io.StringIO()
+        write_adat(_make_minimal_v2_adat(), buf)
+        assert '!Checksum' not in buf.getvalue()
+
+    def test_read_v2_from_file_path(self, tmp_path):
+        """read_adat accepts a file path string and handles v2.0 content."""
+        adat = _make_minimal_v2_adat()
+        path = tmp_path / 'test_v2.adat'
+        with open(path, 'w') as f:
+            write_adat(adat, f)
+        rt = read_adat(str(path))
+        assert rt.header_metadata.get('FileVersion') == '2.0'
+        assert rt.shape == adat.shape
+
+    def test_missing_rfu_values_handled(self):
+        """NA values in the RFU matrix are represented as NaN floats after read."""
+        import math
+
+        adat = _make_minimal_v2_adat()
+        buf = io.StringIO()
+        write_adat(adat, buf)
+        content = buf.getvalue()
+        # Replace one RFU value with empty (simulates missing data)
+        content = content.replace('1000.0\t1000.0', 'NA\t1000.0', 1)
+        with pytest.raises(ValueError):
+            # Attempting to parse a non-numeric RFU value raises ValueError
+            read_adat(io.StringIO(content))
+
+    def test_all_header_fields_round_trip(self):
+        """Every field in the closed v2.0 header set survives a round-trip."""
+        adat = _make_minimal_v2_adat(
+            header={
+                'Title': 'Full Round-trip Test',
+                'StudyMatrix': 'CSF',
+                'StudyOrganism': 'Mouse',
+                'SOMAmerReferenceSource': '2025-01-01',
+                'AssayVersion': 'v4.1',
+                'UseRestriction': 'RUO',
+            }
+        )
+        rt = _roundtrip(adat)
+        for key in adat.header_metadata:
+            assert (
+                key in rt.header_metadata
+            ), f'Missing header key after roundtrip: {key}'
+
+
+# ---------------------------------------------------------------------------
+# Task 4.2: v2.0 field type validation on read
+# ---------------------------------------------------------------------------
+
+
+class TestV2TypeValidationInteger:
+    def test_non_integer_float_warns(self, caplog):
+        adat = _make_minimal_v2_adat(
+            row_names=['SampleId', 'SampleType', 'PlateId', 'Subarray'],
+            row_values=[
+                ['S1', 'S2'],
+                ['Sample', 'Sample'],
+                ['PLT001', 'PLT001'],
+                ['3.5', '3'],
+            ],
+        )
+        buf = io.StringIO()
+        write_adat(adat, buf)
+        buf.seek(0)
+        with caplog.at_level(logging.WARNING, logger='somadata.io.adat.file'):
+            read_adat(buf)
+        messages = [r.message for r in caplog.records]
+        assert any('Subarray' in m and 'Integer' in m for m in messages)
+
+    def test_non_numeric_integer_warns(self, caplog):
+        adat = _make_minimal_v2_adat(
+            row_names=['SampleId', 'SampleType', 'PlateId', 'Subarray'],
+            row_values=[
+                ['S1'],
+                ['Sample'],
+                ['PLT001'],
+                ['not_an_int'],
+            ],
+        )
+        buf = io.StringIO()
+        write_adat(adat, buf)
+        buf.seek(0)
+        with caplog.at_level(logging.WARNING, logger='somadata.io.adat.file'):
+            read_adat(buf)
+        messages = [r.message for r in caplog.records]
+        assert any('Subarray' in m and 'Integer' in m for m in messages)
+
+    def test_valid_integer_no_warn(self, caplog):
+        adat = _make_minimal_v2_adat(
+            row_names=['SampleId', 'SampleType', 'PlateId', 'Subarray'],
+            row_values=[
+                ['S1', 'S2'],
+                ['Sample', 'Sample'],
+                ['PLT001', 'PLT001'],
+                ['3', '4'],
+            ],
+        )
+        buf = io.StringIO()
+        write_adat(adat, buf)
+        buf.seek(0)
+        with caplog.at_level(logging.WARNING, logger='somadata.io.adat.file'):
+            read_adat(buf)
+        type_violations = [
+            r for r in caplog.records if 'v2.0 type violation' in r.message
+        ]
+        assert not type_violations
+
+    def test_missing_value_no_warn_for_integer(self, caplog):
+        """Empty string and 'NA' in an Integer field must not trigger a warning."""
+        adat = _make_minimal_v2_adat(
+            row_names=['SampleId', 'SampleType', 'PlateId', 'Subarray'],
+            row_values=[
+                ['S1', 'S2'],
+                ['Sample', 'Sample'],
+                ['PLT001', 'PLT001'],
+                ['', 'NA'],
+            ],
+        )
+        buf = io.StringIO()
+        write_adat(adat, buf)
+        buf.seek(0)
+        with caplog.at_level(logging.WARNING, logger='somadata.io.adat.file'):
+            read_adat(buf)
+        type_violations = [
+            r for r in caplog.records if 'v2.0 type violation' in r.message
+        ]
+        assert not type_violations
+
+
+class TestV2TypeValidationDecimal:
+    def test_non_numeric_decimal_warns(self, caplog):
+        adat = _make_minimal_v2_adat(
+            row_names=['SampleId', 'SampleType', 'PlateId', 'HybNormScaleFactor'],
+            row_values=[
+                ['S1', 'S2'],
+                ['Sample', 'Sample'],
+                ['PLT001', 'PLT001'],
+                ['not_a_number', '1.05'],
+            ],
+        )
+        buf = io.StringIO()
+        write_adat(adat, buf)
+        buf.seek(0)
+        with caplog.at_level(logging.WARNING, logger='somadata.io.adat.file'):
+            read_adat(buf)
+        messages = [r.message for r in caplog.records]
+        assert any('HybNormScaleFactor' in m and 'Decimal' in m for m in messages)
+
+    def test_valid_decimal_no_warn(self, caplog):
+        adat = _make_minimal_v2_adat(
+            row_names=['SampleId', 'SampleType', 'PlateId', 'HybNormScaleFactor'],
+            row_values=[
+                ['S1', 'S2'],
+                ['Sample', 'Sample'],
+                ['PLT001', 'PLT001'],
+                ['1.05', '0.98'],
+            ],
+        )
+        buf = io.StringIO()
+        write_adat(adat, buf)
+        buf.seek(0)
+        with caplog.at_level(logging.WARNING, logger='somadata.io.adat.file'):
+            read_adat(buf)
+        type_violations = [
+            r for r in caplog.records if 'v2.0 type violation' in r.message
+        ]
+        assert not type_violations
+
+    def test_missing_decimal_no_warn(self, caplog):
+        adat = _make_minimal_v2_adat(
+            row_names=['SampleId', 'SampleType', 'PlateId', 'HybNormScaleFactor'],
+            row_values=[
+                ['S1', 'S2'],
+                ['Sample', 'Sample'],
+                ['PLT001', 'PLT001'],
+                ['', 'NA'],
+            ],
+        )
+        buf = io.StringIO()
+        write_adat(adat, buf)
+        buf.seek(0)
+        with caplog.at_level(logging.WARNING, logger='somadata.io.adat.file'):
+            read_adat(buf)
+        type_violations = [
+            r for r in caplog.records if 'v2.0 type violation' in r.message
+        ]
+        assert not type_violations
+
+    def test_dynamic_decimal_prefix_warns(self, caplog):
+        """Dynamic Decimal fields like NormScale_* also trigger validation."""
+        adat = _make_minimal_v2_adat(
+            row_names=['SampleId', 'SampleType', 'PlateId', 'NormScale_20'],
+            row_values=[
+                ['S1'],
+                ['Sample'],
+                ['PLT001'],
+                ['BAD'],
+            ],
+        )
+        buf = io.StringIO()
+        write_adat(adat, buf)
+        buf.seek(0)
+        with caplog.at_level(logging.WARNING, logger='somadata.io.adat.file'):
+            read_adat(buf)
+        messages = [r.message for r in caplog.records]
+        assert any('NormScale_20' in m and 'Decimal' in m for m in messages)
+
+
+class TestV2TypeValidationDate:
+    def test_non_iso8601_date_warns(self, caplog):
+        adat = _make_minimal_v2_adat(
+            row_names=['SampleId', 'SampleType', 'PlateId', 'PlateRunDate'],
+            row_values=[
+                ['S1', 'S2'],
+                ['Sample', 'Sample'],
+                ['PLT001', 'PLT001'],
+                ['01/31/2026', '2026-01-31'],  # first is not ISO 8601
+            ],
+        )
+        buf = io.StringIO()
+        write_adat(adat, buf)
+        buf.seek(0)
+        with caplog.at_level(logging.WARNING, logger='somadata.io.adat.file'):
+            read_adat(buf)
+        messages = [r.message for r in caplog.records]
+        assert any('PlateRunDate' in m and 'Date' in m for m in messages)
+
+    def test_valid_date_no_warn(self, caplog):
+        adat = _make_minimal_v2_adat(
+            row_names=['SampleId', 'SampleType', 'PlateId', 'PlateRunDate'],
+            row_values=[
+                ['S1', 'S2'],
+                ['Sample', 'Sample'],
+                ['PLT001', 'PLT001'],
+                ['2026-01-31', '2025-12-01'],
+            ],
+        )
+        buf = io.StringIO()
+        write_adat(adat, buf)
+        buf.seek(0)
+        with caplog.at_level(logging.WARNING, logger='somadata.io.adat.file'):
+            read_adat(buf)
+        type_violations = [
+            r for r in caplog.records if 'v2.0 type violation' in r.message
+        ]
+        assert not type_violations
+
+    def test_iso8601_datetime_no_warn(self, caplog):
+        """Full ISO 8601 datetime (with T and Z) is also valid."""
+        adat = _make_minimal_v2_adat(
+            row_names=['SampleId', 'SampleType', 'PlateId', 'PlateRunDate'],
+            row_values=[
+                ['S1'],
+                ['Sample'],
+                ['PLT001'],
+                ['2026-07-15T20:54:06Z'],
+            ],
+        )
+        buf = io.StringIO()
+        write_adat(adat, buf)
+        buf.seek(0)
+        with caplog.at_level(logging.WARNING, logger='somadata.io.adat.file'):
+            read_adat(buf)
+        type_violations = [
+            r for r in caplog.records if 'v2.0 type violation' in r.message
+        ]
+        assert not type_violations
+
+    def test_missing_date_no_warn(self, caplog):
+        adat = _make_minimal_v2_adat(
+            row_names=['SampleId', 'SampleType', 'PlateId', 'PlateRunDate'],
+            row_values=[
+                ['S1', 'S2'],
+                ['Sample', 'Sample'],
+                ['PLT001', 'PLT001'],
+                ['', 'NA'],
+            ],
+        )
+        buf = io.StringIO()
+        write_adat(adat, buf)
+        buf.seek(0)
+        with caplog.at_level(logging.WARNING, logger='somadata.io.adat.file'):
+            read_adat(buf)
+        type_violations = [
+            r for r in caplog.records if 'v2.0 type violation' in r.message
+        ]
+        assert not type_violations
+
+
+class TestV2TypeValidationString:
+    def test_long_string_warns(self, caplog):
+        """A string value over 1024 characters in a String field must log a warning."""
+        long_value = 'x' * 1025
+        adat = _make_minimal_v2_adat(
+            row_names=['SampleId', 'SampleType', 'PlateId'],
+            row_values=[
+                [long_value],
+                ['Sample'],
+                ['PLT001'],
+            ],
+        )
+        buf = io.StringIO()
+        write_adat(adat, buf)
+        buf.seek(0)
+        with caplog.at_level(logging.WARNING, logger='somadata.io.adat.file'):
+            read_adat(buf)
+        messages = [r.message for r in caplog.records]
+        assert any('SampleId' in m and 'String' in m for m in messages)
+
+    def test_exactly_1024_chars_no_warn(self, caplog):
+        ok_value = 'y' * 1024
+        adat = _make_minimal_v2_adat(
+            row_names=['SampleId', 'SampleType', 'PlateId'],
+            row_values=[
+                [ok_value],
+                ['Sample'],
+                ['PLT001'],
+            ],
+        )
+        buf = io.StringIO()
+        write_adat(adat, buf)
+        buf.seek(0)
+        with caplog.at_level(logging.WARNING, logger='somadata.io.adat.file'):
+            read_adat(buf)
+        type_violations = [
+            r for r in caplog.records if 'v2.0 type violation' in r.message
+        ]
+        assert not type_violations
+
+
+class TestV2TypeValidationColData:
+    def test_integer_col_field_non_integer_warns(self, caplog):
+        """EntrezGeneId is INTEGER; a float value must log a warning."""
+        adat = _make_minimal_v2_adat(
+            col_levels={
+                'SeqId': ['10000-01'],
+                'EntrezGeneId': ['12.5'],  # not a whole number
+            }
+        )
+        buf = io.StringIO()
+        write_adat(adat, buf)
+        buf.seek(0)
+        with caplog.at_level(logging.WARNING, logger='somadata.io.adat.file'):
+            read_adat(buf)
+        messages = [r.message for r in caplog.records]
+        assert any('EntrezGeneId' in m and 'Integer' in m for m in messages)
+
+    def test_decimal_col_field_non_numeric_warns(self, caplog):
+        """A Ref.Array.* field is DECIMAL; a non-numeric value must log a warning."""
+        adat = _make_minimal_v2_adat(
+            col_levels={
+                'SeqId': ['10000-01'],
+                'Ref.Array.PlateScale_CAL001': ['NOT_A_FLOAT'],
+            }
+        )
+        buf = io.StringIO()
+        write_adat(adat, buf)
+        buf.seek(0)
+        with caplog.at_level(logging.WARNING, logger='somadata.io.adat.file'):
+            read_adat(buf)
+        messages = [r.message for r in caplog.records]
+        assert any(
+            'Ref.Array.PlateScale_CAL001' in m and 'Decimal' in m for m in messages
+        )
+
+    def test_missing_na_col_field_no_warn(self, caplog):
+        """'N/A' in a Decimal COL_DATA field (e.g., Ref.*) must not log a warning."""
+        adat = _make_minimal_v2_adat(
+            col_levels={
+                'SeqId': ['10000-01', '10001-02'],
+                'Ref.Array.PlateScale_CAL001': ['N/A', '986.5'],
+            }
+        )
+        buf = io.StringIO()
+        write_adat(adat, buf)
+        buf.seek(0)
+        with caplog.at_level(logging.WARNING, logger='somadata.io.adat.file'):
+            read_adat(buf)
+        type_violations = [
+            r for r in caplog.records if 'v2.0 type violation' in r.message
+        ]
+        assert not type_violations
+
+    def test_valid_integer_col_field_no_warn(self, caplog):
+        adat = _make_minimal_v2_adat(
+            col_levels={
+                'SeqId': ['10000-01'],
+                'EntrezGeneId': ['8514'],
+            }
+        )
+        buf = io.StringIO()
+        write_adat(adat, buf)
+        buf.seek(0)
+        with caplog.at_level(logging.WARNING, logger='somadata.io.adat.file'):
+            read_adat(buf)
+        type_violations = [
+            r for r in caplog.records if 'v2.0 type violation' in r.message
+        ]
+        assert not type_violations
+
+
+class TestV2TypeValidationNonV2:
+    def test_no_validation_on_pre_v2_adat(self, caplog):
+        """Type validation must not run for pre-v2.0 ADATs."""
+        index = pd.MultiIndex.from_arrays(
+            [['S1'], ['not_an_int']],
+            names=['SampleId', 'Subarray'],
+        )
+        cols = pd.MultiIndex.from_arrays([['10000-01']], names=['SeqId'])
+        adat = Adat(
+            data=[[1000.0]],
+            index=index,
+            columns=cols,
+            header_metadata={'FileVersion': '1.2'},
+        )
+        buf = io.StringIO()
+        from somadata.io.adat.file import _write_adat
+
+        _write_adat(adat, buf)
+        buf.seek(0)
+        with caplog.at_level(logging.WARNING, logger='somadata.io.adat.file'):
+            read_adat(buf)
+        type_violations = [
+            r for r in caplog.records if 'v2.0 type violation' in r.message
+        ]
+        assert not type_violations
+
+
+class TestV2TypeValidationCleanFile:
+    def test_compliant_v2_adat_no_type_violations(self, caplog):
+        """A well-formed v2.0 Adat with typed fields produces zero type log warnings."""
+        adat = _make_minimal_v2_adat(
+            row_names=[
+                'SampleId',
+                'SampleType',
+                'PlateId',
+                'Subarray',
+                'HybNormScaleFactor',
+                'PlateRunDate',
+            ],
+            row_values=[
+                ['S1', 'S2'],
+                ['Sample', 'Calibrator'],
+                ['PLT001', 'PLT001'],
+                ['3', '3'],
+                ['1.05', '0.98'],
+                ['2026-01-31', '2026-01-31'],
+            ],
+            col_levels={
+                'SeqId': ['10000-01', '10001-02'],
+                'EntrezGeneId': ['8514', '3479'],
+                'Ref.Array.PlateScale_CAL001': ['986.5', '262.5'],
+            },
+        )
+        buf = io.StringIO()
+        write_adat(adat, buf)
+        buf.seek(0)
+        with caplog.at_level(logging.WARNING, logger='somadata.io.adat.file'):
+            read_adat(buf)
+        type_violations = [
+            r for r in caplog.records if 'v2.0 type violation' in r.message
+        ]
+        assert not type_violations, f'Unexpected type violations: {type_violations}'

--- a/tests/io/adat/test_read_adat_v2.py
+++ b/tests/io/adat/test_read_adat_v2.py
@@ -196,14 +196,12 @@ class TestV2ReaderDispatch:
         assert rt.shape == adat.shape
 
     def test_missing_rfu_values_handled(self):
-        """NA values in the RFU matrix are represented as NaN floats after read."""
-        import math
-
+        """Non-numeric RFU values (e.g., 'NA') raise ValueError on read."""
         adat = _make_minimal_v2_adat()
         buf = io.StringIO()
         write_adat(adat, buf)
         content = buf.getvalue()
-        # Replace one RFU value with empty (simulates missing data)
+        # Replace one RFU value with a non-numeric sentinel (simulates missing data)
         content = content.replace('1000.0\t1000.0', 'NA\t1000.0', 1)
         with pytest.raises(ValueError):
             # Attempting to parse a non-numeric RFU value raises ValueError


### PR DESCRIPTION
Task 4.1: read_adat() correctly handles v2.0 format files (no '!' prefix on Name/Type rows, JSON header values parsed as dicts). Round-trip tests confirm write -> read preserves shape, RFU values, all metadata, and multi-level COL_DATA/ROW_DATA.

Task 4.2: _validate_v2_field_values() checks Integer, Decimal, Date, JSON, and String field types after parsing any v2.0 ADAT. Detection is vectorized via pandas (pd.to_numeric, pd.to_datetime, str.len). Date parsing uses datetime.fromisoformat() for calendar validity. Violations are logged via logger.warning() (one warning per field, listing bad indices). Pre-v2.0 ADATs bypass validation entirely. Missing value sentinels ('', 'NA', 'N/A') are silently accepted for all types.